### PR TITLE
[TIG-81] User profile button and link updates

### DIFF
--- a/src/components/groupProfile/GroupMemberPanel.js
+++ b/src/components/groupProfile/GroupMemberPanel.js
@@ -42,11 +42,16 @@ const GroupMemberPanel = ({
             flexWrap: 'wrap'
           }}
         >
-          {groupMembers.map((member, index) => (
-            <Tooltip title={member.name}>
+          {groupMembers.map((member) => {
+            const { avatar, user_role, user_id, name } = member;
+            const userIsOwner = user_role === 'owner';
+            return (
+              <Tooltip
+                title={`${name}${userIsOwner ? ' (Owner)' : ''}`}
+                key={user_id}
+              >
               <IconButton
-                aria-label="user avatar"
-                disableRipple={true}
+                  disableRipple
                 onClick={() => handleOpen(member)}
                 sx={{ display: 'block', mb: { xs: '0.25em' } }}
               >
@@ -60,31 +65,32 @@ const GroupMemberPanel = ({
                       strokeWidth={1}
                     />
                   }
-                  invisible={member.user_role === 'member'}
+                    invisible={!userIsOwner}
                 >
                   <Avatar
                     variant="rounded"
                     aria-hidden="true"
                     sx={{
                       background: '#5bc1ab',
-                      // padding: '20px',
                       borderRadius: '99em',
                       boxShadow: '8px 8px 16px rgb(0 0 0 / 43%)',
                       border: '1px solid #000000',
+                        cursor: 'pointer',
                       width: {
                         xs: 120,
                       },
                       height: {
                         xs: 120,
                       },
-                      ':hover': { cursor: 'pointer' },
                     }}
-                    src={member.avatar ? member.avatar : null}
+                      src={avatar ? avatar : null}
+                      alt=""
                   >
-                    {member.name.charAt(0)}
+                      {name.charAt(0)}
                   </Avatar>
                 </Badge>
-                <Box component="div" sx={{
+                  <Box
+                    sx={{
                   color: '#000',
                   fontSize: '0.75rem',
                   maxWidth: '80%',
@@ -92,11 +98,12 @@ const GroupMemberPanel = ({
                   margin: '0 auto'
                 }}
                   >
-                  {member.name}
+                    {name}
                 </Box>
               </IconButton>
             </Tooltip>
-          ))}
+            );
+          })}
           {openDialog && (
             <GroupMemberPanelDialog
               openDialog={openDialog}

--- a/src/components/groupProfile/GroupMemberPanel.js
+++ b/src/components/groupProfile/GroupMemberPanel.js
@@ -57,7 +57,15 @@ const GroupMemberPanel = ({
               <IconButton
                   disableRipple
                 onClick={() => handleOpen(member)}
-                sx={{ display: 'block', mb: { xs: '0.25em' } }}
+                  sx={{
+                    display: 'block',
+                    borderRadius: '1rem',
+                    padding: '0.5rem 0.75rem',
+                    mb: { xs: '0.25em' },
+                    ':hover, :focus': {
+                      backgroundColor: 'rgba(255,255,255,0.75)',
+                    },
+                  }}
               >
                 <Badge
                   overlap="rectangular"

--- a/src/components/groupProfile/GroupMemberPanel.js
+++ b/src/components/groupProfile/GroupMemberPanel.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Grid, Avatar, Tooltip, IconButton, Paper, Badge, Box } from '@mui/material';
 import StarIcon from '@mui/icons-material/Star';
 import GroupMemberPanelDialog from './GroupMemberPanelDialog';
+import useTranslation from '../customHooks/translations';
 
 const GroupMemberPanel = ({
   groupMembers,
@@ -11,6 +12,7 @@ const GroupMemberPanel = ({
   currentUserOwner,
   cognitoUser,
 }) => {
+  const translation = useTranslation();
   const [openDialog, setOpenDialog] = useState(false);
   const [selectedMember, setSelectedMember] = useState();
 
@@ -47,7 +49,9 @@ const GroupMemberPanel = ({
             const userIsOwner = user_role === 'owner';
             return (
               <Tooltip
-                title={`${name}${userIsOwner ? ' (Owner)' : ''}`}
+                title={`${name}${
+                  userIsOwner ? translation.userNoteGroupOwner : ''
+                }`}
                 key={user_id}
               >
               <IconButton

--- a/src/components/groupProfile/GroupMemberPanelDialog.js
+++ b/src/components/groupProfile/GroupMemberPanelDialog.js
@@ -4,10 +4,7 @@ import {
   DialogTitle,
   DialogContent,
   List,
-  ListItemIcon,
-  ListItemText,
   IconButton,
-  ListItemButton,
 } from '@mui/material';
 import {
   AccountCircle,
@@ -27,6 +24,7 @@ import { getAllUsersInGroup } from '../../graphql/queries';
 import { API } from 'aws-amplify';
 import { useNavigate } from 'react-router-dom';
 import LeaveGroupDialogContent from './LeaveGroupDialogContent';
+import { MemberDialogAction } from './MemberDialogAction';
 
 import useTranslation from '../customHooks/translations';
 
@@ -137,26 +135,23 @@ const GroupMemberDialog = ({
       (currentUserOwner || userType === 'Admin') && (
         <>
           {selectedMember.user_role === 'member' ? (
-            <ListItemButton onClick={promoteUser}>
-              <ListItemIcon>
-                <PersonAddAlt1 />
-              </ListItemIcon>
-              <ListItemText>{translation.promoteUserToOwner}</ListItemText>
-            </ListItemButton>
+            <MemberDialogAction
+              onSelectAction={promoteUser}
+              actionLabel={translation.promoteUserToOwner}
+              actionIcon={PersonAddAlt1}
+            />
           ) : (
-            <ListItemButton onClick={demoteOwner}>
-              <ListItemIcon>
-                <PersonRemove />
-              </ListItemIcon>
-              <ListItemText>{translation.demoteUserToMember}</ListItemText>
-            </ListItemButton>
+            <MemberDialogAction
+              onSelectAction={demoteOwner}
+              actionLabel={translation.demoteUserToMember}
+              actionIcon={PersonRemove}
+            />
           )}
-          <ListItemButton onClick={removeUser}>
-            <ListItemIcon>
-              <GroupRemove />
-            </ListItemIcon>
-            <ListItemText>{translation.removeUserFromGroup}</ListItemText>
-          </ListItemButton>
+          <MemberDialogAction
+            onSelectAction={removeUser}
+            actionLabel={translation.removeUserFromGroup}
+            actionIcon={GroupRemove}
+          />
         </>
       )
     );
@@ -195,20 +190,17 @@ const GroupMemberDialog = ({
                   selectedMember.user_role.slice(1)}
               </DialogContent>
               <List sx={{ pt: '1em', pb: '2em' }}>
-                <ListItemButton
+                <MemberDialogAction
                   autoFocus
-                  onClick={() =>
+                  onSelectAction={() =>
                     setDialogDisplay({
                       ...dialogDisplay,
                       leaveGroupWarning: true,
                     })
                   }
-                >
-                  <ListItemIcon>
-                    <ExitToApp />
-                  </ListItemIcon>
-                  <ListItemText>{translation.leaveGroup}</ListItemText>
-                </ListItemButton>
+                  actionLabel={translation.leaveGroup}
+                  actionIcon={ExitToApp}
+                />
               </List>
             </>
           ) : (
@@ -222,17 +214,14 @@ const GroupMemberDialog = ({
                     selectedMember.user_role.slice(1)}
                 </DialogContent>
                 <List sx={{ pt: '1em', pb: '2em' }}>
-                  <ListItemButton
+                  <MemberDialogAction
                     autoFocus
-                    onClick={() =>
+                    onSelectAction={() =>
                       navigate(`/user-profile/${selectedMember.user_id}`)
                     }
-                  >
-                    <ListItemIcon>
-                      <AccountCircle />
-                    </ListItemIcon>
-                    <ListItemText>{translation.viewUserProfile}</ListItemText>
-                  </ListItemButton>
+                    actionLabel={translation.viewUserProfile}
+                    actionIcon={AccountCircle}
+                  />
                   {renderOwnerAdminView()}
                 </List>
               </>

--- a/src/components/groupProfile/GroupMemberPanelDialog.js
+++ b/src/components/groupProfile/GroupMemberPanelDialog.js
@@ -4,10 +4,10 @@ import {
   DialogTitle,
   DialogContent,
   List,
-  ListItem,
   ListItemIcon,
   ListItemText,
   IconButton,
+  ListItemButton,
 } from '@mui/material';
 import {
   AccountCircle,
@@ -137,26 +137,26 @@ const GroupMemberDialog = ({
       (currentUserOwner || userType === 'Admin') && (
         <>
           {selectedMember.user_role === 'member' ? (
-            <ListItem autoFocus button onClick={promoteUser}>
+            <ListItemButton onClick={promoteUser}>
               <ListItemIcon>
                 <PersonAddAlt1 />
               </ListItemIcon>
               <ListItemText>{translation.promoteUserToOwner}</ListItemText>
-            </ListItem>
+            </ListItemButton>
           ) : (
-            <ListItem autoFocus button onClick={demoteOwner}>
+            <ListItemButton onClick={demoteOwner}>
               <ListItemIcon>
                 <PersonRemove />
               </ListItemIcon>
               <ListItemText>{translation.demoteUserToMember}</ListItemText>
-            </ListItem>
+            </ListItemButton>
           )}
-          <ListItem autoFocus button onClick={removeUser}>
+          <ListItemButton onClick={removeUser}>
             <ListItemIcon>
               <GroupRemove />
             </ListItemIcon>
             <ListItemText>{translation.removeUserFromGroup}</ListItemText>
-          </ListItem>
+          </ListItemButton>
         </>
       )
     );
@@ -195,9 +195,8 @@ const GroupMemberDialog = ({
                   selectedMember.user_role.slice(1)}
               </DialogContent>
               <List sx={{ pt: '1em', pb: '2em' }}>
-                <ListItem
+                <ListItemButton
                   autoFocus
-                  button
                   onClick={() =>
                     setDialogDisplay({
                       ...dialogDisplay,
@@ -209,7 +208,7 @@ const GroupMemberDialog = ({
                     <ExitToApp />
                   </ListItemIcon>
                   <ListItemText>{translation.leaveGroup}</ListItemText>
-                </ListItem>
+                </ListItemButton>
               </List>
             </>
           ) : (
@@ -223,9 +222,8 @@ const GroupMemberDialog = ({
                     selectedMember.user_role.slice(1)}
                 </DialogContent>
                 <List sx={{ pt: '1em', pb: '2em' }}>
-                  <ListItem
+                  <ListItemButton
                     autoFocus
-                    button
                     onClick={() =>
                       navigate(`/user-profile/${selectedMember.user_id}`)
                     }
@@ -234,7 +232,7 @@ const GroupMemberDialog = ({
                       <AccountCircle />
                     </ListItemIcon>
                     <ListItemText>{translation.viewUserProfile}</ListItemText>
-                  </ListItem>
+                  </ListItemButton>
                   {renderOwnerAdminView()}
                 </List>
               </>

--- a/src/components/groupProfile/MemberDialogAction.js
+++ b/src/components/groupProfile/MemberDialogAction.js
@@ -1,0 +1,28 @@
+import { ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
+
+const buttonStyles = {
+  border: 'solid 0.1rem rgba(255,255,255,0.35)',
+  borderRadius: '0.35rem',
+  '&:not(:last-child)': {
+    marginBottom: '0.75rem',
+  },
+  '&:hover, &:focus': {
+    borderColor: 'white',
+  },
+};
+
+export const MemberDialogAction = ({
+  onSelectAction,
+  actionLabel,
+  actionIcon: ActionIcon,
+  ...props
+}) => {
+  return (
+    <ListItemButton onClick={onSelectAction} sx={buttonStyles} {...props}>
+      <ListItemIcon>
+        <ActionIcon alt="" />
+      </ListItemIcon>
+      <ListItemText>{actionLabel}</ListItemText>
+    </ListItemButton>
+  );
+};

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -283,7 +283,7 @@ const translations = {
   ninetyDays: '90 Days',
   oneYear: 'Year',
   co2SavedDuring: 'CO2 Saved during the past {0}',
-  totalGramsSavedCO2PerDayAllActions: 'Total Grams of CO2 Saved Per Day For All Actions',
+  userNoteGroupOwner: ' (Owner)',
 };
 
 export default translations;

--- a/src/localization/es.js
+++ b/src/localization/es.js
@@ -282,7 +282,7 @@ const translations = {
   ninetyDays: '90 Días',
   oneYear: 'Año',
   co2SavedDuring: 'CO2 Ahorrado durante los últimos {0}',
-  totalGramsSavedCO2PerDayAllActions: 'Total de Gramos de CO2 Ahorrados por Día Para Todas las Acciones',
+  userNoteGroupOwner: ' (el dueño)',
 };
 
 export default translations;

--- a/src/localization/fr.js
+++ b/src/localization/fr.js
@@ -285,7 +285,7 @@ const translations = {
   ninetyDays: '90 Jours',
   oneYear: 'Année',
   co2SavedDuring: 'CO2 Sauvé au cours des {0} derniers',
-  totalGramsSavedCO2PerDayAllActions: 'Grammes CO2 Sauvés au Total Par Jour Pour Toutes les Actions',
+  userNoteGroupOwner: ' (propriétaire)',
 };
 
 export default translations;


### PR DESCRIPTION
## Description

* [ClickUp ticket](https://app.clickup.com/t/9009201449/TIG-81)

This PR improves the tooltip and screen reader context when focusing on a member item within the "Group Members" list. Each item also has a stronger hover/focus state visible now. Once a member is selected and their actions dialog opens, the action buttons have been visually improved to distinguish them as buttons rather than static text.

## Screenshots

**Updated hover/focus state and updated tooltip (and button aria label) text on member item within group list:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/627091f4-8ec7-4bad-8ce4-e178f6b9b4c0)

**Focus and static states visible for actions within member info dialog:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/d0a15d5c-5f42-4129-b67b-822a4104d390)
