### PR TITLE
[TIG-393] Log Action - Action buttons on last step

### DIFF
--- a/src/components/customHooks/use-update-submitted-action.js
+++ b/src/components/customHooks/use-update-submitted-action.js
@@ -1,0 +1,55 @@
+import { API } from 'aws-amplify';
+import { useEffect } from 'react';
+import { updateSubmittedAction } from '../../graphql/mutations';
+
+export const getPointsEarnedFromCO2Saved = (CO2Saved = 0) =>
+  Math.ceil(CO2Saved);
+
+export const useUpdateSubmittedAction = (
+  updateData = {},
+  autoUpdateOnInit = false
+) => {
+  const transformDataForRequest = (initialData) => {
+    const {
+      actionId,
+      actionDate,
+      firstQuizAnswerCorrect,
+      totalCO2Saved,
+      isValidated = false,
+      quizAnswered,
+      userId,
+      quizId,
+    } = initialData;
+
+    return {
+      action_id: actionId,
+      date_of_action: actionDate,
+      first_quiz_answer_correct: firstQuizAnswerCorrect,
+      g_co2_saved: totalCO2Saved,
+      is_validated: isValidated,
+      points_earned: getPointsEarnedFromCO2Saved(totalCO2Saved),
+      quiz_answered: quizAnswered,
+      user_id: userId,
+      quiz_id: quizId,
+    };
+  };
+
+  // Creates and submits the action, returns the submitted action id that is stored in database
+  const sendUpdate = async () =>
+    await API.graphql({
+      query: updateSubmittedAction,
+      variables: transformDataForRequest(updateData),
+    });
+
+  useEffect(() => {
+    if (autoUpdateOnInit) {
+      sendUpdate();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return {
+    sendUpdate,
+    updateData,
+  };
+};

--- a/src/components/logAction/ActionButtons.js
+++ b/src/components/logAction/ActionButtons.js
@@ -1,48 +1,51 @@
 import React from 'react';
 import { Box, Button } from '@mui/material';
 
+const buttonStyles = {
+  padding: '0.5em 1.5em',
+  borderRadius: '2rem',
+  fontWeight: 'bold',
+  textTransform: 'capitalize',
+  flex: '1 0 max-content',
+  maxWidth: '14em',
+};
+
 const ActionButtons = ({
+  backOnClick = () => {},
+  backText = null,
+  forwardDisabled = false,
   forwardOnClick,
-  backOnClick,
   forwardText,
-  backText,
 }) => {
   return (
     <Box
-      component="div"
       sx={{
-        display: 'flex',
-        justifyContent: 'center',
         alignItems: 'center',
-        m: '0 0 1.25em',
-        flexDirection: { xs: 'row' },
-        gap: { xs: '10px', md: '10px' },
-        width: { xs: '100%' },
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '0.75rem',
+        justifyContent: 'center',
+        marginBottom: '1.25rem',
       }}
     >
+      {backText && (
+        <Button
+          onClick={backOnClick}
+          sx={{
+            ...buttonStyles,
+            color: 'white',
+            borderColor: 'white',
+          }}
+          variant="outlined"
+        >
+          {backText}
+        </Button>
+      )}
       <Button
-        onClick={backOnClick}
-        variant="outlined"
-        sx={{
-          width: '100%',
-          padding: '.5em 1em',
-          fontSize: '1.2rem',
-          borderRadius: '35px',
-          color: 'white',
-        }}
-      >
-        {backText}
-      </Button>
-      <Button
+        disabled={forwardDisabled}
         onClick={forwardOnClick}
+        sx={buttonStyles}
         variant="contained"
-        // disabled={disableButton}
-        sx={{
-          width: '100%',
-          padding: '.5em 1em',
-          fontSize: '1.2rem',
-          borderRadius: '35px',
-        }}
       >
         {forwardText}
       </Button>

--- a/src/components/logAction/ActionButtons.js
+++ b/src/components/logAction/ActionButtons.js
@@ -6,8 +6,8 @@ const buttonStyles = {
   borderRadius: '2rem',
   fontWeight: 'bold',
   textTransform: 'capitalize',
-  flex: '1 0 max-content',
-  maxWidth: '14em',
+  flex: '1 0 calc(50% - 0.75rem)',
+  minWidth: 'max-content',
 };
 
 const ActionButtons = ({

--- a/src/components/logAction/ActionFact.js
+++ b/src/components/logAction/ActionFact.js
@@ -3,7 +3,6 @@ import { Grid, Box, Typography, CircularProgress, Button } from '@mui/material';
 import { API } from 'aws-amplify';
 import { getQuizPoolForUser } from '../../graphql/queries';
 import Modal from 'react-modal';
-
 import useTranslation from '../customHooks/translations';
 import { useContentTranslationsContext } from '../contexts/ContentTranslationsContext';
 import {
@@ -11,6 +10,7 @@ import {
   createSubmittedActionItems,
 } from '../../graphql/mutations';
 import { getSingleSubmittedAction } from '../../graphql/queries';
+import ActionButtons from './ActionButtons';
 
 Modal.setAppElement('#root');
 
@@ -259,21 +259,16 @@ const ActionFact = ({
           width: { xs: '50%' },
         }}
       >
-        <Button
-          onClick={() => setActiveStep(activeStep + 1)}
-          variant="contained"
-          sx={{
-            width: '100%',
-            padding: '.5em 1em',
-            fontSize: '1.2rem',
-            borderRadius: '35px',
-            color: 'white',
-          }}
-          disabled={loading}
-        >
-          {translation.done}{' '}
-          {loading && <CircularProgress sx={{ margin: '0 1em' }} />}
-        </Button>
+        <ActionButtons
+          forwardOnClick={() => setActiveStep(activeStep + 1)}
+          forwardDisabled={loading}
+          forwardText={
+            <>
+              {translation.done}
+              {loading && <CircularProgress sx={{ margin: '0 1em' }} />}
+            </>
+          }
+        />
       </Box>
     </Grid>
   );

--- a/src/components/logAction/ActionFact.js
+++ b/src/components/logAction/ActionFact.js
@@ -205,10 +205,13 @@ const ActionFact = ({
     >
       <Box>
         <Typography>
-          Your{' '}
-          <Typography sx={{ color: actionStyle.color, display: 'inline' }}>
-            {selectedAction.action_name}
-          </Typography>{' '}
+          Your
+          <Typography
+            variant="span"
+            sx={{ color: actionStyle.color, display: 'inline' }}
+          >
+            {` ${selectedAction.action_name} `}
+          </Typography>
           action is being submitted.
         </Typography>
       </Box>

--- a/src/components/logAction/ShareOnSocialPanel.js
+++ b/src/components/logAction/ShareOnSocialPanel.js
@@ -1,21 +1,24 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Box } from '@mui/material';
 import ActionButtons from './ActionButtons';
 import useTranslation from '../customHooks/translations';
 import { useUpdateSubmittedAction } from '../customHooks/use-update-submitted-action';
+import { PAGE_PATHS } from '../../constants/page-paths';
 
 const filterUpdateDataFromProps = (props) => ({
-  actionId: props.actionId,
   actionDate: props.actionDate,
+  actionId: props.actionId,
   firstQuizAnswerCorrect: props.firstQuizAnswerCorrect,
-  totalCO2Saved: props.totalCO2Saved,
   quizAnswered: props.quizAnswered,
-  userId: props.userId,
   quizId: props.quizId,
+  totalCO2Saved: props.totalCO2Saved,
+  userId: props.userId,
 });
 
-const ShareOnSocialPanel = (props) => {
+const ShareOnSocialPanel = ({ addAnotherAction, ...props }) => {
   const translation = useTranslation();
+  const navigate = useNavigate();
 
   // Update the current action with quiz info on init of this panel
   useUpdateSubmittedAction(filterUpdateDataFromProps(props), true);
@@ -24,9 +27,9 @@ const ShareOnSocialPanel = (props) => {
     <Box>
       <div>I dare you to match my action by...</div>
       <ActionButtons
-        forwardOnClick={() => {}}
-        backOnClick={() => {}}
+        backOnClick={addAnotherAction}
         backText={translation.logActionButtonAddAnother}
+        forwardOnClick={() => navigate(PAGE_PATHS.DASHBOARD)}
         forwardText={translation.logActionButtonAllDone}
       />
     </Box>

--- a/src/components/logAction/ShareOnSocialPanel.js
+++ b/src/components/logAction/ShareOnSocialPanel.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import ActionButtons from './ActionButtons';
 import useTranslation from '../customHooks/translations';
 import { useUpdateSubmittedAction } from '../customHooks/use-update-submitted-action';
@@ -25,7 +25,20 @@ const ShareOnSocialPanel = ({ addAnotherAction, ...props }) => {
 
   return (
     <Box>
-      <div>I dare you to match my action by...</div>
+      <Box
+        sx={{
+          background: 'white',
+          padding: '0.75rem',
+          marginBottom: '2.5rem',
+        }}
+      >
+        <Typography color="black">
+          I dare you to match my action by [placeholder for activity info]
+        </Typography>
+        <Typography color="black" textTransform="uppercase">
+          <strong>{translation.commit2ActHashtag}</strong>
+        </Typography>
+      </Box>
       <ActionButtons
         backOnClick={addAnotherAction}
         backText={translation.logActionButtonAddAnother}

--- a/src/components/logAction/ShareOnSocialPanel.js
+++ b/src/components/logAction/ShareOnSocialPanel.js
@@ -1,46 +1,36 @@
-import React, { useEffect } from 'react';
-
+import React from 'react';
+import { Box } from '@mui/material';
+import ActionButtons from './ActionButtons';
 import useTranslation from '../customHooks/translations';
-import { updateSubmittedAction } from '../../graphql/mutations';
-import { API } from 'aws-amplify';
+import { useUpdateSubmittedAction } from '../customHooks/use-update-submitted-action';
 
-const ShareOnSocialPanel = ({
-  quizAnswered,
-  firstQuizAnswerCorrect,
-  quizId,
-  userId,
-  totalCO2Saved,
-  actionId,
-  actionDate,
-}) => {
-  useEffect(() => {
-    submitBonus();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+const filterUpdateDataFromProps = (props) => ({
+  actionId: props.actionId,
+  actionDate: props.actionDate,
+  firstQuizAnswerCorrect: props.firstQuizAnswerCorrect,
+  totalCO2Saved: props.totalCO2Saved,
+  quizAnswered: props.quizAnswered,
+  userId: props.userId,
+  quizId: props.quizId,
+});
 
-  const submitBonus = async () => {
-    //creates and submits the action, returns the submitted action id that is stored in database
-
-    await API.graphql({
-      query: updateSubmittedAction,
-      variables: {
-        action_id: actionId,
-        date_of_action: actionDate,
-        first_quiz_answer_correct: firstQuizAnswerCorrect,
-        g_co2_saved: totalCO2Saved,
-        is_validated: false,
-        points_earned: Math.ceil(totalCO2Saved),
-        quiz_answered: quizAnswered,
-        user_id: userId,
-        quiz_id: quizId,
-      },
-    });
-  };
+const ShareOnSocialPanel = (props) => {
   const translation = useTranslation();
 
-  //Update submitted action here and add quizAnswered and firstQuizAnswerCorrect
+  // Update the current action with quiz info on init of this panel
+  useUpdateSubmittedAction(filterUpdateDataFromProps(props), true);
 
-  return <div>I dare you to match my action by...</div>;
+  return (
+    <Box>
+      <div>I dare you to match my action by...</div>
+      <ActionButtons
+        forwardOnClick={() => {}}
+        backOnClick={() => {}}
+        backText={translation.logActionButtonAddAnother}
+        forwardText={translation.logActionButtonAllDone}
+      />
+    </Box>
+  );
 };
 
 export default ShareOnSocialPanel;

--- a/src/constants/page-paths.js
+++ b/src/constants/page-paths.js
@@ -1,0 +1,10 @@
+export const PAGE_PATHS = {
+  DASHBOARD: '/',
+  LOG_ACTION: '/log-action',
+  ACTIONS: '/actions',
+  MY_GROUPS: '/my-groups',
+  FIND_GROUP: '/find-group',
+  CREATE_GROUP: '/create-group',
+  VALIDATE_ACTIONS: '/validate-actions',
+  MY_ACCOUNT: '/account-settings',
+};

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -304,6 +304,8 @@ const translations = {
   continue: 'Continue',
   done: 'Done',
   extraPoints: 'Get Extra Points!',
+  logActionButtonAddAnother: 'Add Another',
+  logActionButtonAllDone: 'All Done',
 };
 
 export default translations;

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -306,6 +306,7 @@ const translations = {
   extraPoints: 'Get Extra Points!',
   logActionButtonAddAnother: 'Add Another',
   logActionButtonAllDone: 'All Done',
+  commit2ActHashtag: '#Commit2Act',
 };
 
 export default translations;

--- a/src/pages/SelfReportMenu.js
+++ b/src/pages/SelfReportMenu.js
@@ -265,12 +265,6 @@ const SelfReportMenu = ({ user }) => {
         item
         sx={{
           backgroundColor: 'none',
-          width: { xs: '100%', md: '85%' },
-          padding: { xs: '1em', md: '2em 2em 5em' },
-          borderRadius: '7px',
-          borderWidth: '2px',
-          borderStyle: 'solid',
-          borderColor: actionStyle.color,
           '& .Mui-focused, & .Mui-focused .MuiOutlinedInput-notchedOutline': {
             color: actionStyle.color,
             borderColor: actionStyle.color,

--- a/src/pages/SelfReportMenu.js
+++ b/src/pages/SelfReportMenu.js
@@ -60,6 +60,11 @@ const SelfReportMenu = ({ user }) => {
     translation.logActionStep6,
   ];
 
+  const resetLogAction = () => {
+    setSelectedAction(undefined);
+    setActiveStep(0);
+  };
+
   const [actionOptions, setActionOptions] = useState([]);
   /** @type {[boolean, React.Dispatch<React.SetStateAction<boolean>>]} */
   const [loading, setLoading] = useState(true);
@@ -191,6 +196,7 @@ const SelfReportMenu = ({ user }) => {
             actionDate={selectedDate}
             totalCO2Saved={totalCO2Saved}
             actionId={selectedAction?.action_id}
+            addAnotherAction={resetLogAction}
           />
         )}
       </>


### PR DESCRIPTION
## Description

* [ClickUp ticket](https://app.clickup.com/t/9009201449/TIG-393)

This PR adds the "Add Another" and "All Done" action buttons at the end of the logging flow. "Add Another" resets the logging flow and starts fresh at the type selection screen, while "All Done" redirects the user to the Dashboard.

Extra stuff in this PR:

* Added `PAGE_PATHS` constant for global use to avoid static strings throughout files
* Extracted update request on final step to custom hook
* Fixed rendering issue with nested `p` tags
* Styling for `ActionButtons` and update to allow single button

**Note: Changes in this PR are specifically for a  mobile screen size. Updates for larger screens will be addressed during a later phase.**

## Screenshots

**Mobile view with buttons in place, dummy text for sharing prompt, and container padding/border removed:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/2bdef409-f2ce-4a4e-896f-e9ef05effff5)

## Testing Instructions

* Pull down and install the branch locally
* Run the UI and open it in browser
* With a mobile-sized browser window (or device simulator), head to the "Log Action" page
* Step through the screens, skipping the quiz portion
* Once on the final screen, confirm that the "Add Another" and "All Done" buttons show up
* Try each button and confirm it follows the action described above