### PR TITLE
[TIG-394] Step indicators updated for count and designs

### DIFF
--- a/src/components/StepCounter.js
+++ b/src/components/StepCounter.js
@@ -1,24 +1,23 @@
 import { Box, Typography } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
-import { LOG_STEPS, TOTAL_LOG_STEPS } from '../constants/log-steps';
 import useTranslation from './customHooks/translations';
+import { LOG_STEPS, TOTAL_LOG_STEPS } from '../constants/log-steps';
 
 const getStepCounterStyles = (currentColor) => ({
-  margin: '1em auto',
+  margin: '0 auto',
   textAlign: 'center',
   fontSize: {
     xs: '0.725rem',
-    md: '0.825rem',
+    sm: '0.825rem',
     lg: '1rem',
   },
   ol: {
-    display: 'flex',
     flexWrap: 'wrap',
     justifyContent: 'center',
     alignItems: 'center',
     listStyle: 'none',
     padding: '0',
-    margin: '0',
+    margin: '1em 0',
     gap: {
       xs: '0.75em',
       lg: '1.25em',
@@ -41,11 +40,11 @@ const getStepCounterStyles = (currentColor) => ({
       display: 'block',
       color: 'black',
       width: {
-        xs: '3em',
+        xs: '2.25em',
         md: '1.75em',
       },
       height: {
-        xs: '0.75em',
+        xs: '0.5em',
         md: '1.75em',
       },
     },
@@ -71,6 +70,15 @@ const getStepCounterStyles = (currentColor) => ({
 
 export const StepCounter = ({ activeStep, currentColor }) => {
   const translation = useTranslation();
+
+  // We don't count the final screen as a numbered step, so we'll
+  // render nothing if it is not included in the LOG_STEPS array.
+  if (!LOG_STEPS.find((step) => step.number === activeStep)) return null;
+
+  // We aren't showing the counter while selecting an action type
+  // but it still counts as a numbered step, so we'll conditionally
+  // hide the visual counter for the first screen.
+  const listDisplayStyle = { display: activeStep === 0 ? 'none' : 'flex' };
   const stepCounterStyles = getStepCounterStyles(currentColor);
 
   return (
@@ -82,12 +90,13 @@ export const StepCounter = ({ activeStep, currentColor }) => {
           TOTAL_LOG_STEPS
         )}
       </Box>
-      <Box component="ol">
+      <Box component="ol" sx={listDisplayStyle}>
         {LOG_STEPS.map(({ number, title, name }) => {
           const isCompleted = number < activeStep;
           const displayNumber = number + 1;
 
           let className = '',
+            dotContent = `"${displayNumber}"`,
             statusText = null;
 
           if (number === activeStep) {
@@ -96,9 +105,12 @@ export const StepCounter = ({ activeStep, currentColor }) => {
           }
           if (isCompleted) {
             className = 'completed';
+            dotContent = '"\\2714"';
             statusText = 'logActionStepCompleted';
           }
 
+          // Concatenate the step number, completed/current status,
+          // and step title as the visually-hidden label per step.
           const visuallyHiddenText = [
             displayNumber,
             statusText ? translation[statusText] : '',
@@ -114,7 +126,7 @@ export const StepCounter = ({ activeStep, currentColor }) => {
                 '&:before': {
                   content: {
                     xs: '""',
-                    md: `"${isCompleted ? '\\2714' : displayNumber}"`,
+                    md: dotContent,
                   },
                 },
               }}

--- a/src/components/StepCounter.js
+++ b/src/components/StepCounter.js
@@ -1,0 +1,108 @@
+import { Box, Typography } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
+import { LOG_STEPS, TOTAL_LOG_STEPS } from '../constants/log-steps';
+import useTranslation from './customHooks/translations';
+
+const getStepStatus = (activeStep, currentStep) => {
+  const stepStatus = {
+    className: '',
+    helperText: null,
+  };
+  if (currentStep === activeStep) {
+    stepStatus.className = 'current';
+    stepStatus.helperText = 'logActionStepCurrent';
+  }
+  if (currentStep < activeStep) {
+    stepStatus.className = 'completed';
+    stepStatus.helperText = 'logActionStepCompleted';
+  }
+  return stepStatus;
+};
+
+const getStepCounterStyles = (currentColor) => ({
+  width: 'max-content',
+  margin: '1em',
+  textAlign: 'center',
+  fontSize: {
+    xs: '0.725rem',
+  },
+  ol: {
+    display: 'flex',
+    justifyItems: 'space-between',
+    gap: '0.75em',
+    listStyle: 'none',
+    padding: '0',
+    margin: '0',
+  },
+  li: {
+    color: 'white',
+    '&:before': {
+      content: '""',
+      display: 'block',
+      width: {
+        xs: '3em',
+        md: '1em',
+      },
+      height: {
+        xs: '0.75em',
+        md: '1em',
+      },
+      background: 'white',
+      borderRadius: '1em',
+      outline: 'solid 0.15em transparent',
+      outlineOffset: '0.2em',
+    },
+    '&.current:before, &.completed:before': {
+      background: currentColor,
+    },
+    '&.current:before': {
+      outlineColor: currentColor,
+    },
+  },
+  '.title': {
+    display: {
+      xs: 'none',
+      md: 'block',
+    },
+  },
+});
+
+export const StepCounter = ({ activeStep, currentColor }) => {
+  const translation = useTranslation();
+  const stepCounterStyles = getStepCounterStyles(currentColor);
+
+  if (activeStep === 0) return null;
+
+  return (
+    <Box sx={stepCounterStyles}>
+      <Box aria-live="polite" sx={visuallyHidden}>
+        {translation.formatString(
+          translation.logActionStepOfTotal,
+          activeStep,
+          TOTAL_LOG_STEPS
+        )}
+      </Box>
+      <ol>
+        {LOG_STEPS.map((step) => {
+          const { className, helperText } = getStepStatus(
+            activeStep,
+            step.number
+          );
+
+          return (
+            <li key={step.name} className={className}>
+              <Typography variant="span" sx={visuallyHidden}>
+                {step.number}
+                {' ' + helperText ? translation[helperText] : ''}
+                {' ' + translation[step.title] ? translation[step.title] : ''}
+              </Typography>
+              <Typography variant="span" className="title">
+                {translation[step.title] ? translation[step.title] : ''}
+              </Typography>
+            </li>
+          );
+        })}
+      </ol>
+    </Box>
+  );
+};

--- a/src/components/StepCounter.js
+++ b/src/components/StepCounter.js
@@ -6,15 +6,15 @@ import useTranslation from './customHooks/translations';
 const getStepStatus = (activeStep, currentStep) => {
   const stepStatus = {
     className: '',
-    helperText: null,
+    statusText: null,
   };
   if (currentStep === activeStep) {
     stepStatus.className = 'current';
-    stepStatus.helperText = 'logActionStepCurrent';
+    stepStatus.statusText = 'logActionStepCurrent';
   }
   if (currentStep < activeStep) {
     stepStatus.className = 'completed';
-    stepStatus.helperText = 'logActionStepCompleted';
+    stepStatus.statusText = 'logActionStepCompleted';
   }
   return stepStatus;
 };
@@ -71,33 +71,32 @@ export const StepCounter = ({ activeStep, currentColor }) => {
   const translation = useTranslation();
   const stepCounterStyles = getStepCounterStyles(currentColor);
 
-  if (activeStep === 0) return null;
-
   return (
     <Box sx={stepCounterStyles}>
       <Box aria-live="polite" sx={visuallyHidden}>
         {translation.formatString(
           translation.logActionStepOfTotal,
-          activeStep,
+          activeStep + 1,
           TOTAL_LOG_STEPS
         )}
       </Box>
       <ol>
-        {LOG_STEPS.map((step) => {
-          const { className, helperText } = getStepStatus(
-            activeStep,
-            step.number
-          );
+        {LOG_STEPS.map(({ number, title, name }) => {
+          const { className, statusText } = getStepStatus(activeStep, number);
+
+          const visuallyHiddenText = [
+            number + 1,
+            statusText ? translation[statusText] : '',
+            translation[title] ? translation[title] : '',
+          ].join(' ');
 
           return (
-            <li key={step.name} className={className}>
+            <li key={name} className={className}>
               <Typography variant="span" sx={visuallyHidden}>
-                {step.number}
-                {' ' + helperText ? translation[helperText] : ''}
-                {' ' + translation[step.title] ? translation[step.title] : ''}
+                {visuallyHiddenText}
               </Typography>
               <Typography variant="span" className="title">
-                {translation[step.title] ? translation[step.title] : ''}
+                {translation[title] ? translation[title] : ''}
               </Typography>
             </li>
           );

--- a/src/components/StepCounter.js
+++ b/src/components/StepCounter.js
@@ -3,54 +3,51 @@ import { visuallyHidden } from '@mui/utils';
 import { LOG_STEPS, TOTAL_LOG_STEPS } from '../constants/log-steps';
 import useTranslation from './customHooks/translations';
 
-const getStepStatus = (activeStep, currentStep) => {
-  const stepStatus = {
-    className: '',
-    statusText: null,
-  };
-  if (currentStep === activeStep) {
-    stepStatus.className = 'current';
-    stepStatus.statusText = 'logActionStepCurrent';
-  }
-  if (currentStep < activeStep) {
-    stepStatus.className = 'completed';
-    stepStatus.statusText = 'logActionStepCompleted';
-  }
-  return stepStatus;
-};
-
 const getStepCounterStyles = (currentColor) => ({
-  width: 'max-content',
-  margin: '1em',
+  margin: '1em auto',
   textAlign: 'center',
   fontSize: {
     xs: '0.725rem',
+    md: '0.825rem',
+    lg: '1rem',
   },
   ol: {
     display: 'flex',
-    justifyItems: 'space-between',
-    gap: '0.75em',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    alignItems: 'center',
     listStyle: 'none',
     padding: '0',
     margin: '0',
+    gap: {
+      xs: '0.75em',
+      lg: '1.25em',
+    },
   },
   li: {
     color: 'white',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    display: {
+      xs: 'block',
+      md: 'flex',
+    },
     '&:before': {
-      content: '""',
+      background: 'rgba(255,255,255,0.75)',
+      borderRadius: '1em',
+      outline: 'solid 0.15em transparent',
+      outlineOffset: '0.15em',
+      lineHeight: '1.75',
       display: 'block',
+      color: 'black',
       width: {
         xs: '3em',
-        md: '1em',
+        md: '1.75em',
       },
       height: {
         xs: '0.75em',
-        md: '1em',
+        md: '1.75em',
       },
-      background: 'white',
-      borderRadius: '1em',
-      outline: 'solid 0.15em transparent',
-      outlineOffset: '0.2em',
     },
     '&.current:before, &.completed:before': {
       background: currentColor,
@@ -60,6 +57,11 @@ const getStepCounterStyles = (currentColor) => ({
     },
   },
   '.title': {
+    margin: {
+      xs: '0',
+      md: '0 0.5em',
+      lg: '0 0.75em',
+    },
     display: {
       xs: 'none',
       md: 'block',
@@ -80,28 +82,53 @@ export const StepCounter = ({ activeStep, currentColor }) => {
           TOTAL_LOG_STEPS
         )}
       </Box>
-      <ol>
+      <Box component="ol">
         {LOG_STEPS.map(({ number, title, name }) => {
-          const { className, statusText } = getStepStatus(activeStep, number);
+          const isCompleted = number < activeStep;
+          const displayNumber = number + 1;
+
+          let className = '',
+            statusText = null;
+
+          if (number === activeStep) {
+            className = 'current';
+            statusText = 'logActionStepCurrent';
+          }
+          if (isCompleted) {
+            className = 'completed';
+            statusText = 'logActionStepCompleted';
+          }
 
           const visuallyHiddenText = [
-            number + 1,
+            displayNumber,
             statusText ? translation[statusText] : '',
             translation[title] ? translation[title] : '',
           ].join(' ');
 
           return (
-            <li key={name} className={className}>
+            <Box
+              component="li"
+              key={name}
+              className={className}
+              sx={{
+                '&:before': {
+                  content: {
+                    xs: '""',
+                    md: `"${isCompleted ? '\\2714' : displayNumber}"`,
+                  },
+                },
+              }}
+            >
               <Typography variant="span" sx={visuallyHidden}>
                 {visuallyHiddenText}
               </Typography>
-              <Typography variant="span" className="title">
+              <Typography variant="span" className="title" aria-hidden="true">
                 {translation[title] ? translation[title] : ''}
               </Typography>
-            </li>
+            </Box>
           );
         })}
-      </ol>
+      </Box>
     </Box>
   );
 };

--- a/src/constants/log-steps.js
+++ b/src/constants/log-steps.js
@@ -24,11 +24,6 @@ export const LOG_STEPS = [
     name: 'bonus-question',
     title: 'logActionStep5',
   },
-  {
-    number: 5,
-    name: 'share-on-social',
-    title: 'logActionStep6',
-  },
 ];
 
 export const TOTAL_LOG_STEPS = LOG_STEPS.length;

--- a/src/constants/log-steps.js
+++ b/src/constants/log-steps.js
@@ -1,0 +1,29 @@
+export const LOG_STEPS = [
+  {
+    number: 1,
+    name: 'add-action',
+    title: 'logActionStep2',
+  },
+  {
+    number: 2,
+    name: 'action-fact',
+    title: 'logActionStep3',
+  },
+  {
+    number: 3,
+    name: 'co2-saved',
+    title: 'logActionStep4',
+  },
+  {
+    number: 4,
+    name: 'bonus-question',
+    title: 'logActionStep5',
+  },
+  {
+    number: 5,
+    name: 'share-on-social',
+    title: 'logActionStep6',
+  },
+];
+
+export const TOTAL_LOG_STEPS = LOG_STEPS.length;

--- a/src/constants/log-steps.js
+++ b/src/constants/log-steps.js
@@ -1,5 +1,10 @@
 export const LOG_STEPS = [
   {
+    number: 0,
+    name: 'select-action',
+    title: 'logActionStep1',
+  },
+  {
     number: 1,
     name: 'add-action',
     title: 'logActionStep2',

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -179,7 +179,7 @@ const translations = {
   logActionStep1: 'Select Action',
   logActionStep2: 'Add Action',
   logActionStep3: 'Nice Work',
-  logActionStep4: '',
+  logActionStep4: 'CO2 Saved',
   logActionStep5: 'Bonus Question',
   logActionStep6: 'Share On Social',
   next: 'Next',
@@ -307,6 +307,9 @@ const translations = {
   logActionButtonAddAnother: 'Add Another',
   logActionButtonAllDone: 'All Done',
   commit2ActHashtag: '#Commit2Act',
+  logActionStepCompleted: 'Completed',
+  logActionStepCurrent: 'Current',
+  logActionStepOfTotal: 'Step {0} of {1}',
 };
 
 export default translations;

--- a/src/pages/SelfReportMenu.js
+++ b/src/pages/SelfReportMenu.js
@@ -1,14 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { API } from 'aws-amplify';
 import { getAllUngraveyardedActions } from '../graphql/queries';
-import {
-  Typography,
-  Grid,
-  Stepper,
-  Step,
-  StepLabel,
-  CircularProgress,
-} from '@mui/material';
+import { Typography, Grid, CircularProgress } from '@mui/material';
 import { format } from 'date-fns';
 import ActionFact from '../components/logAction/ActionFact';
 import BonusPointQuiz from '../components/logAction/BonusPointQuiz';
@@ -224,28 +217,6 @@ const SelfReportMenu = ({ user }) => {
           {selectedAction.action_name}
         </Typography>
       )}
-      {/* display full stepper on screens larger than 900px, otherwise display mobile stepper */}
-      <Stepper
-        activeStep={activeStep}
-        sx={{ mb: '1em', display: { xs: 'none', md: 'flex' } }}
-      >
-        {steps.map((step, index) => (
-          <Step
-            key={index}
-            sx={{
-              '& .MuiStepLabel-root .MuiStepLabel-iconContainer .Mui-active': {
-                color: actionStyle.color, // circle color (ACTIVE)
-              },
-              '& .MuiStepLabel-root .MuiStepLabel-iconContainer .Mui-completed ':
-                {
-                  color: actionStyle.color, // circle color (COMPLETED)
-                },
-            }}
-          >
-            <StepLabel>{step}</StepLabel>
-          </Step>
-        ))}
-      </Stepper>
       <StepCounter currentColor={actionStyle.color} activeStep={activeStep} />
       <Grid
         item

--- a/src/pages/SelfReportMenu.js
+++ b/src/pages/SelfReportMenu.js
@@ -7,7 +7,6 @@ import {
   Stepper,
   Step,
   StepLabel,
-  MobileStepper,
   CircularProgress,
 } from '@mui/material';
 import { format } from 'date-fns';
@@ -20,6 +19,7 @@ import AddActionPanel from '../components/logAction/AddActionPanel';
 
 import useTranslation from '../components/customHooks/translations';
 import ShareOnSocialPanel from '../components/logAction/ShareOnSocialPanel';
+import { StepCounter } from '../components/StepCounter';
 
 const ActionStyles = {
   0: { color: '#ffffff' },
@@ -246,21 +246,7 @@ const SelfReportMenu = ({ user }) => {
           </Step>
         ))}
       </Stepper>
-      <MobileStepper
-        variant="dots"
-        steps={7}
-        position="static"
-        activeStep={activeStep}
-        sx={{
-          display: { xs: 'flex', md: 'none' },
-          justifyContent: 'center',
-          background: 'none',
-          mb: '1em',
-          '& .MuiMobileStepper-dotActive': {
-            backgroundColor: actionStyle.color,
-          },
-        }}
-      />{' '}
+      <StepCounter currentColor={actionStyle.color} activeStep={activeStep} />
       <Grid
         item
         sx={{


### PR DESCRIPTION
## Description

* [ClickUp ticket](https://app.clickup.com/t/9009201449/TIG-394)

This PR updates the former `MobileStepper` and `Stepper` Material-UI components to use a single `StepCounter` with massively improved labelling for assistive tech. Updates to the current step are now announced via `aria-live`, and the current and completed steps are called out when using a screen reader to navigate through the step indicators. 

This component has been styled for all screen sizes, including the simplified mobile version and fully numbered and labelled large screen version.

## Screenshots

**No visual step indicator on the first screen, as designed:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/d6e5426f-1731-41cb-817e-3ca3bb27ad07)

**Indicator visible on the second screen, with the current dot outlined:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/0afb82e2-ff54-4e69-86a5-3a7c78fbd1bf)

**Step counter does not render on the "sharing" screen, after the other steps:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/a409a51f-d719-4d54-8fe9-ae16708fe049)

**Step counter on larger screens, with numbers and step titles visible:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/9afa940d-d460-4125-a9da-5e711ebcaef0)

**Rendered markup with `aria-live` version to announce updated step and summarized visually hidden text for each  step:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/43368a9b-94fc-4767-ae54-ed6d31f0e5f2)

