### PR TITLE
[TIG-424] Reset Log Action flow when link is selected from nav

### DIFF
--- a/src/pages/LogAction.js
+++ b/src/pages/LogAction.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { API } from 'aws-amplify';
 import { getAllUngraveyardedActions } from '../graphql/queries';
 import { Grid, CircularProgress } from '@mui/material';
@@ -7,7 +8,6 @@ import ActionFact from '../components/logAction/ActionFact';
 import BonusPointQuiz from '../components/logAction/BonusPointQuiz';
 import CO2SavedScreen from '../components/logAction/Co2SavedScreen';
 import AllActions from '../components/AllActions';
-import { useNavigate } from 'react-router-dom';
 import AddActionPanel from '../components/logAction/AddActionPanel';
 import ShareOnSocialPanel from '../components/logAction/ShareOnSocialPanel';
 import { LogStepHeader } from '../components/LogStepHeader';
@@ -104,6 +104,12 @@ const LogAction = ({ user }) => {
   const handleDateChange = (newDate) => {
     setSelectedDate(format(new Date(newDate), 'yyyy-MM-dd'));
   };
+
+  const { actionId } = useParams();
+
+  useEffect(() => {
+    if (!actionId) resetLogAction();
+  }, [actionId]);
 
   return (
     <ActiveStepContext.Provider

--- a/src/pages/LogAction.js
+++ b/src/pages/LogAction.js
@@ -23,7 +23,7 @@ const ActionStyles = {
   12: { color: '#FFD467' },
 };
 
-const SelfReportMenu = ({ user }) => {
+const LogAction = ({ user }) => {
   const [selectedDate, setSelectedDate] = useState(
     format(new Date(), 'yyyy-MM-dd')
   );
@@ -105,83 +105,6 @@ const SelfReportMenu = ({ user }) => {
     setSelectedDate(format(new Date(newDate), 'yyyy-MM-dd'));
   };
 
-  const renderFormStep = () => {
-    return (
-      <>
-        {loading ? <CircularProgress /> : <></>}
-        {activeStep === 0 && (
-          <AllActions
-            setSelectedAction={setSelectedAction}
-            actionOptions={actionOptions}
-          />
-        )}
-        {activeStep === 1 && (
-          <AddActionPanel
-            selectedDate={selectedDate}
-            handleDateChange={handleDateChange}
-            setTotalCO2Saved={setTotalCO2Saved}
-            actionItemValues={actionItemValues}
-            setActionItemValues={setActionItemValues}
-            skipBonusQuestion={skipBonusQuestion}
-            selectedImage={selectedImage}
-            setSelectedImage={setSelectedImage}
-          />
-        )}
-        {selectedAction && activeStep === 2 && (
-          <ActionFact
-            selectedAction={selectedAction}
-            actionStyle={actionStyle}
-            user={user}
-            quiz={quiz}
-            setQuiz={setQuiz}
-            setSkipBonusQuestion={setSkipBonusQuestion}
-            activeStep={activeStep}
-            setActiveStep={setActiveStep}
-            actionDate={selectedDate}
-            totalCO2Saved={totalCO2Saved}
-            actionItemValues={actionItemValues}
-            selectedImage={selectedImage}
-            setValidationSuccess={setValidationSuccess}
-          />
-        )}
-        {activeStep === 3 && (
-          <CO2SavedScreen
-            totalCO2Saved={totalCO2Saved}
-            setActiveStep={setActiveStep}
-            skipBonusQuestion={skipBonusQuestion}
-            validationSuccess={validationSuccess}
-            activeStep={activeStep}
-            actionStyle={actionStyle}
-          />
-        )}
-        {activeStep === 4 && (
-          <BonusPointQuiz
-            quiz={quiz}
-            setQuizAnswered={setQuizAnswered}
-            setFirstQuizAnswerCorrect={setFirstQuizAnswerCorrect}
-            setActiveStep={setActiveStep}
-            activeStep={activeStep}
-            actionStyle={actionStyle}
-          />
-        )}
-
-        {/* To Do: Update submitted action with firstQuizAnswerCorrect and quiz_answered */}
-        {activeStep === 5 && (
-          <ShareOnSocialPanel
-            quizAnswered={quizAnswered}
-            firstQuizAnswerCorrect={firstQuizAnswerCorrect}
-            userId={user?.user_id}
-            quizId={quiz ? quiz.quiz_id : null}
-            actionDate={selectedDate}
-            totalCO2Saved={totalCO2Saved}
-            actionId={selectedAction?.action_id}
-            addAnotherAction={resetLogAction}
-          />
-        )}
-      </>
-    );
-  };
-
   return (
     <ActiveStepContext.Provider
       value={{
@@ -209,14 +132,83 @@ const SelfReportMenu = ({ user }) => {
             },
           }}
         >
-          {renderFormStep()}
+          {loading ? <CircularProgress /> : null}
+          {activeStep === 0 && (
+            <AllActions
+              setSelectedAction={setSelectedAction}
+              actionOptions={actionOptions}
+            />
+          )}
+          {activeStep === 1 && (
+            <AddActionPanel
+              selectedDate={selectedDate}
+              handleDateChange={handleDateChange}
+              setTotalCO2Saved={setTotalCO2Saved}
+              actionItemValues={actionItemValues}
+              setActionItemValues={setActionItemValues}
+              skipBonusQuestion={skipBonusQuestion}
+              selectedImage={selectedImage}
+              setSelectedImage={setSelectedImage}
+            />
+          )}
+          {selectedAction && activeStep === 2 && (
+            <ActionFact
+              selectedAction={selectedAction}
+              actionStyle={actionStyle}
+              user={user}
+              quiz={quiz}
+              setQuiz={setQuiz}
+              setSkipBonusQuestion={setSkipBonusQuestion}
+              activeStep={activeStep}
+              setActiveStep={setActiveStep}
+              actionDate={selectedDate}
+              totalCO2Saved={totalCO2Saved}
+              actionItemValues={actionItemValues}
+              selectedImage={selectedImage}
+              setValidationSuccess={setValidationSuccess}
+            />
+          )}
+          {activeStep === 3 && (
+            <CO2SavedScreen
+              totalCO2Saved={totalCO2Saved}
+              setActiveStep={setActiveStep}
+              skipBonusQuestion={skipBonusQuestion}
+              validationSuccess={validationSuccess}
+              activeStep={activeStep}
+              actionStyle={actionStyle}
+            />
+          )}
+          {activeStep === 4 && (
+            <BonusPointQuiz
+              quiz={quiz}
+              setQuizAnswered={setQuizAnswered}
+              setFirstQuizAnswerCorrect={setFirstQuizAnswerCorrect}
+              setActiveStep={setActiveStep}
+              activeStep={activeStep}
+              actionStyle={actionStyle}
+            />
+          )}
+
+          {/* To Do: Update submitted action with firstQuizAnswerCorrect and quiz_answered */}
+          {activeStep === 5 && (
+            <ShareOnSocialPanel
+              quizAnswered={quizAnswered}
+              firstQuizAnswerCorrect={firstQuizAnswerCorrect}
+              userId={user?.user_id}
+              quizId={quiz ? quiz.quiz_id : null}
+              actionDate={selectedDate}
+              totalCO2Saved={totalCO2Saved}
+              actionId={selectedAction?.action_id}
+              addAnotherAction={resetLogAction}
+            />
+          )}
         </Grid>
       </Grid>
     </ActiveStepContext.Provider>
   );
 };
 
-export default SelfReportMenu;
+export default LogAction;
 
 /**
  * @param {any[]} actionOptions

--- a/src/pages/LogAction.js
+++ b/src/pages/LogAction.js
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Grid, CircularProgress, Typography, Box } from '@mui/material';
+import { ChevronLeft } from '@mui/icons-material';
 import { API } from 'aws-amplify';
-import { getAllUngraveyardedActions } from '../graphql/queries';
-import { Grid, CircularProgress } from '@mui/material';
 import { format } from 'date-fns';
+import { getAllUngraveyardedActions } from '../graphql/queries';
 import ActionFact from '../components/logAction/ActionFact';
 import BonusPointQuiz from '../components/logAction/BonusPointQuiz';
 import CO2SavedScreen from '../components/logAction/Co2SavedScreen';
@@ -12,6 +13,7 @@ import AddActionPanel from '../components/logAction/AddActionPanel';
 import ShareOnSocialPanel from '../components/logAction/ShareOnSocialPanel';
 import { LogStepHeader } from '../components/LogStepHeader';
 import { ActiveStepContext } from '../hooks/use-active-step-context';
+import useTranslation from '../components/customHooks/translations';
 
 const ActionStyles = {
   0: { color: '#ffffff' },
@@ -24,6 +26,7 @@ const ActionStyles = {
 };
 
 const LogAction = ({ user }) => {
+  const t = useTranslation();
   const [selectedDate, setSelectedDate] = useState(
     format(new Date(), 'yyyy-MM-dd')
   );
@@ -127,6 +130,28 @@ const LogAction = ({ user }) => {
         textAlign="center"
         flexDirection="column"
       >
+        <Box
+          display="flex"
+          justifyContent="flex-start"
+          width="100%"
+          margin="-0.75em 0 0.5em"
+        >
+          {activeStep === 1 && (
+            <Typography
+              component={Link}
+              to="/log-action"
+              display="flex"
+              alignItems="center"
+              justifyContent="flex-start"
+              fontSize={{ xs: '0.775em' }}
+              marginLeft="-0.75em"
+              gap="0.25em"
+            >
+              <ChevronLeft alt="" />
+              <Box component="span">{t.back}</Box>
+            </Typography>
+          )}
+        </Box>
         <LogStepHeader />
         <Grid
           item

--- a/src/views/pageContainer/PageContainer.js
+++ b/src/views/pageContainer/PageContainer.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import clsx from 'clsx';
-import { Route, Routes, useNavigate } from 'react-router-dom';
+import { Route, Routes, useNavigate, Link } from 'react-router-dom';
 import {
   Drawer,
   Toolbar,
@@ -10,6 +10,7 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
+  ListItemButton,
   Box,
 } from '@mui/material';
 import {
@@ -187,34 +188,26 @@ function PageContainer(props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleSideMenu = () => {
+  const handleMenuNavItem = (toPath = null) => {
     updateMenuState(!menuEnabled);
+    if (toPath) navigate(toPath);
   };
 
   useEffect(() => {
     if (mobileView) {
-      handleSideMenu();
+      handleMenuNavItem();
     }
   }, [mobileView]);
 
-  const handleChangePage = (event, newPage) => {
-    handleSideMenu();
-  };
-  //   {
-  //     /* Example side menu is provided below */
-  //   }
   const list = () => (
-    <div
-      className={classes.drawerContainer}
-      // onClick={handleSideMenuClose(false)}
-      // onKeyDown={handleSideMenuClose(false)}
-    >
+    <div className={classes.drawerContainer}>
       <List>
-        <ListItem
-          button
-          key={'logAction'}
-          onClick={() => navigate('/log-action')}
+        <ListItemButton
+          key="logAction"
           className={classes.logAction}
+          component={Link}
+          onClick={handleMenuNavItem}
+          to="/log-action"
         >
           <ListItemIcon>
             <Box
@@ -227,8 +220,8 @@ function PageContainer(props) {
             />
           </ListItemIcon>
           <ListItemText primary={translation.logAction} />
-        </ListItem>
-        <ListItem button key={'home'} onClick={() => navigate('/')}>
+        </ListItemButton>
+        <ListItemButton key={'home'} onClick={() => handleMenuNavItem('/')}>
           <ListItemIcon>
             <Box
               component="img"
@@ -240,8 +233,12 @@ function PageContainer(props) {
             />
           </ListItemIcon>
           <ListItemText primary={translation.dashboard} />
-        </ListItem>
-        <ListItem button key={'Actions'} onClick={() => navigate('/actions')}>
+        </ListItemButton>
+        <ListItem
+          button
+          key={'Actions'}
+          onClick={() => handleMenuNavItem('/actions')}
+        >
           <ListItemIcon>
             <Box
               component="img"
@@ -257,7 +254,7 @@ function PageContainer(props) {
         <ListItem
           button
           key={'mygroups'}
-          onClick={() => navigate('/my-groups')}
+          onClick={() => handleMenuNavItem('/my-groups')}
         >
           <ListItemIcon>
             <Box
@@ -274,7 +271,7 @@ function PageContainer(props) {
         <ListItem
           button
           key={'findGroup'}
-          onClick={() => navigate('/find-group')}
+          onClick={() => handleMenuNavItem('/find-group')}
         >
           <ListItemIcon>
             <Box
@@ -292,7 +289,7 @@ function PageContainer(props) {
         <ListItem
           button
           key={'createGroup'}
-          onClick={() => navigate('/create-group')}
+          onClick={() => handleMenuNavItem('/create-group')}
         >
           <ListItemIcon>
             <Box
@@ -310,7 +307,7 @@ function PageContainer(props) {
         <ListItem
           button
           key={'validateActions'}
-          onClick={() => navigate('/validate-actions')}
+          onClick={() => handleMenuNavItem('/validate-actions')}
         >
           <ListItemIcon>
             <Box
@@ -330,7 +327,7 @@ function PageContainer(props) {
             <ListItem
               button
               key={'adminDashboard'}
-              onClick={() => navigate('/admin-dashboard')}
+              onClick={() => handleMenuNavItem('/admin-dashboard')}
             >
               <ListItemIcon>
                 <AdminPanelSettings />
@@ -347,7 +344,7 @@ function PageContainer(props) {
         <ListItem
           button
           key={'myAccount'}
-          onClick={() => navigate(`/account-settings`)}
+          onClick={() => handleMenuNavItem(`/account-settings`)}
         >
           <ListItemIcon>
             <Box
@@ -404,11 +401,12 @@ function PageContainer(props) {
                 with your app's contents */}
 
           <Routes>
+            <Route path="/log-action" element={<LogAction user={user} />}>
             <Route
-              exact
-              path={'/log-action/*'}
+                path="/log-action/:actionId"
               element={<LogAction user={user} />}
             />
+            </Route>
             <Route
               exact
               path={'/actions'}

--- a/src/views/pageContainer/PageContainer.js
+++ b/src/views/pageContainer/PageContainer.js
@@ -129,7 +129,7 @@ const useStyles = makeStyles()((theme) => {
 
 function PageContainer(props) {
   const theme = useTheme();
-  const mobileView = useMediaQuery(theme.breakpoints.down('sm'));
+  const mobileView = useMediaQuery(theme.breakpoints.down('md'));
   const { menuEnabled, updateMenuState } = props;
 
   const { classes } = useStyles();
@@ -189,7 +189,7 @@ function PageContainer(props) {
   }, []);
 
   const handleMenuNavItem = (toPath = null) => {
-    updateMenuState(!menuEnabled);
+    if (mobileView) updateMenuState(!menuEnabled);
     if (toPath) navigate(toPath);
   };
 
@@ -402,10 +402,10 @@ function PageContainer(props) {
 
           <Routes>
             <Route path="/log-action" element={<LogAction user={user} />}>
-            <Route
+              <Route
                 path="/log-action/:actionId"
-              element={<LogAction user={user} />}
-            />
+                element={<LogAction user={user} />}
+              />
             </Route>
             <Route
               exact

--- a/src/views/pageContainer/PageContainer.js
+++ b/src/views/pageContainer/PageContainer.js
@@ -28,7 +28,7 @@ import { updateMenuState } from '../../actions/menuActions';
 import Landing from '../../pages/Landing';
 import FindGroup from '../../pages/FindGroup';
 import AccountSettings from '../../pages/AccountSettings';
-import SelfReportMenu from '../../pages/SelfReportMenu';
+import LogAction from '../../pages/LogAction';
 import ValidateActions from '../../pages/ValidateActions';
 import CreateGroup from '../../pages/CreateGroup';
 import GroupProfile from '../../pages/GroupProfile';
@@ -407,7 +407,7 @@ function PageContainer(props) {
             <Route
               exact
               path={'/log-action/*'}
-              element={<SelfReportMenu user={user} />}
+              element={<LogAction user={user} />}
             />
             <Route
               exact


### PR DESCRIPTION
## Ticket

* [TIG-424](https://app.clickup.com/t/9009201449/TIG-424)

## Description

This PR addresses a few small items around navigation and the Log Action flow. First, selecting the "Log Action" link from the side nav will reset the flow, regardless of which step the user is on. Next, the side nav will auto-dismiss on mobile when any link is selected. And finally, a "back" link has been added to the second step of Log Action, which returns the user to the "select an action" (step 1) screen.

## Screenshot

**Demo of the "Log Action" menu link and "Back" buttons resetting the flow, as well as the mobile nav automatically dismissing:**

![log-action-reset-flow](https://github.com/TakingITGlobal/commit2act/assets/1672105/1fc00890-cc27-400c-b6e7-e5a660e12aca)
