### PR TITLE
[TIG-425, TIG-401, TIG-402] Log Action container and action buttons cleanup

### DIFF
--- a/src/components/LogStepHeader.js
+++ b/src/components/LogStepHeader.js
@@ -28,7 +28,7 @@ export const LogStepHeader = () => {
   const { activeStep, actionStyle, selectedAction } = useActiveStepContext();
   const stepHeadingText = translation[logStepHeadings[activeStep]];
   return (
-    <Box m={{ xs: '0.5em 0 1.5em' }} textAlign="center">
+    <Box m="0.5em 0" textAlign="center">
       <Box component="header">
         {activeStep > 0 && selectedAction && (
           <Typography

--- a/src/components/logAction/ActionButtons.js
+++ b/src/components/logAction/ActionButtons.js
@@ -3,52 +3,65 @@ import { Box, Button } from '@mui/material';
 
 const buttonStyles = {
   padding: '0.5em 1.5em',
-  borderRadius: '2rem',
+  borderRadius: '2em',
   fontWeight: 'bold',
   textTransform: 'capitalize',
-  flex: '1 0 calc(50% - 0.75rem)',
-  minWidth: 'max-content',
+  borderWidth: 'solid 0.1em transparent',
+  fontSize: { xs: '0.925em', sm: '1em', md: '0.875em' },
+  margin: '0.5em',
+  flexBasis: '50%',
+  minWidth: '10em',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '1.5em',
+  '&:first-of-type': {
+    marginLeft: '0',
+  },
+  '&:last-of-type': {
+    marginRight: '0',
+  },
 };
 
 const ActionButtons = ({
   backOnClick = () => {},
   backText = null,
-  forwardDisabled = false,
   forwardOnClick,
   forwardText,
+  forwardProps = {},
+  backProps = {},
+  children,
 }) => {
+  const backButtonStyles = {
+    ...buttonStyles,
+    color: 'white',
+    borderColor: 'white',
+  };
   return (
-    <Box
-      sx={{
-        alignItems: 'center',
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: '0.75rem',
-        justifyContent: 'center',
-        marginBottom: '1.25rem',
-      }}
-    >
-      {backText && (
+    <Box maxWidth="50rem" margin="1em auto">
+      {children}
+      <Box display="flex" alignItems="center" justifyContent="center">
+        {backText && (
+          <Button
+            onClick={backOnClick}
+            sx={backButtonStyles}
+            variant="outlined"
+            size="large"
+            {...backProps}
+          >
+            {backText}
+          </Button>
+        )}
         <Button
-          onClick={backOnClick}
-          sx={{
-            ...buttonStyles,
-            color: 'white',
-            borderColor: 'white',
-          }}
-          variant="outlined"
+          onClick={forwardOnClick}
+          sx={buttonStyles}
+          variant="contained"
+          size="large"
+          {...forwardProps}
         >
-          {backText}
+          {forwardText}
         </Button>
-      )}
-      <Button
-        disabled={forwardDisabled}
-        onClick={forwardOnClick}
-        sx={buttonStyles}
-        variant="contained"
-      >
-        {forwardText}
-      </Button>
+      </Box>
     </Box>
   );
 };

--- a/src/components/logAction/ActionFact.js
+++ b/src/components/logAction/ActionFact.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Grid, Box, Typography, CircularProgress, Button } from '@mui/material';
+import { Grid, Box, Typography, CircularProgress } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
 import { API } from 'aws-amplify';
 import { getQuizPoolForUser } from '../../graphql/queries';
 import Modal from 'react-modal';
@@ -237,39 +238,30 @@ const ActionFact = ({
         >
           Did you know?{' '}
         </Typography>
-        {/* <button onClick={openModal}>Open Modal</button> */}
         {renderFact()}
       </Box>
-
-      {/* <Modal
-        isOpen={modalIsOpen}
-        onAfterOpen={afterOpenModal}
-        onRequestClose={closeModal}
-        contentLabel="Example Modal"
-        className="sourceModal"
-      >
-        <h2 ref={(_subtitle) => (subtitle = _subtitle)}>Hello</h2>
-        <button onClick={closeModal}>close</button>
-        <div>I am a modal</div>
-      </Modal> */}
-      <Box
-        component="div"
-        sx={{
-          m: '1.25em 0 1.25em',
-          width: { xs: '50%' },
+      <ActionButtons
+        forwardOnClick={() => setActiveStep(activeStep + 1)}
+        forwardProps={{
+          disabled: loading,
         }}
+        forwardText={
+          <>
+            {translation.done}
+            {loading && <CircularProgress />}
+          </>
+        }
       >
-        <ActionButtons
-          forwardOnClick={() => setActiveStep(activeStep + 1)}
-          forwardDisabled={loading}
-          forwardText={
-            <>
-              {translation.done}
-              {loading && <CircularProgress sx={{ margin: '0 1em' }} />}
-            </>
+        <Box aria-live="polite" sx={visuallyHidden}>
+          {
+            translation[
+              loading
+                ? 'logActionValidationLoading'
+                : 'logActionValidationComplete'
+            ]
           }
-        />
-      </Box>
+        </Box>
+      </ActionButtons>
     </Grid>
   );
 };

--- a/src/components/logAction/BonusPointQuiz.js
+++ b/src/components/logAction/BonusPointQuiz.js
@@ -136,51 +136,19 @@ const BonusPointQuiz = ({
       }}
     >
       {isAnswerSelected ? displayAnswer() : displayQuiz()}
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          textAlign: 'center',
-          width: '100%',
+      <ActionButtons
+        forwardOnClick={() => {
+          if (userAnswer) {
+            setActiveStep(activeStep + 1);
+          } else {
+            setIsAnswerSelected(true);
+            setQuizAnswered(true);
+          }
         }}
-      >
-        {!userAnswer ? (
-          <ActionButtons
-            forwardOnClick={() => {
-              setIsAnswerSelected(true);
-              setQuizAnswered(true);
-            }}
-            backOnClick={() => setActiveStep(activeStep + 1)}
-            backText="Skip"
-            forwardText="Submit"
-          />
-        ) : (
-          <Box
-            component="div"
-            sx={{
-              m: '0 0 1.25em',
-              width: { xs: '50%' },
-            }}
-          >
-            <Button
-              onClick={() => {
-                setActiveStep(activeStep + 1);
-              }}
-              variant="contained"
-              sx={{
-                width: '100%',
-                padding: '.5em 1em',
-                fontSize: '1.2rem',
-                borderRadius: '35px',
-                color: 'white',
-              }}
-            >
-              Continue
-            </Button>
-          </Box>
-        )}
-      </Box>
+        backOnClick={() => setActiveStep(activeStep + 1)}
+        backText={translation.bonusQuizSkip}
+        forwardText={translation[userAnswer ? 'continue' : 'bonusQuizSubmit']}
+      />
     </Box>
   );
 };

--- a/src/components/logAction/Co2SavedScreen.js
+++ b/src/components/logAction/Co2SavedScreen.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Typography, Button } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import ActionButtons from './ActionButtons';
 import useTranslation from '../customHooks/translations';
 import { formatCo2Saved } from '../../utils/format-co2-saved';
@@ -77,28 +77,10 @@ const CO2SavedScreen = ({
         }
       </Box>
       {skipBonusQuestion ? (
-        <Box
-          component="div"
-          sx={{
-            m: 'auto 1.25em',
-          }}
-        >
-          <Button
-            onClick={() => {
-              setActiveStep(activeStep + 2);
-            }}
-            variant="contained"
-            sx={{
-              width: '50%',
-              padding: '.5em 1em',
-              fontSize: '1.2rem',
-              borderRadius: '35px',
-              color: 'white',
-            }}
-          >
-            {translation.continue}
-          </Button>
-        </Box>
+        <ActionButtons
+          forwardOnClick={() => setActiveStep(activeStep + 2)}
+          forwardText={translation.continue}
+        />
       ) : (
         <ActionButtons
           forwardOnClick={() => setActiveStep(activeStep + 1)}

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -317,6 +317,8 @@ const translations = {
   shareOnTikTok: 'Share on TikTok',
   copyButtonCopy: 'Copy',
   copyButtonCopied: 'Copied!',
+  logActionValidationLoading: 'Validating action details',
+  logActionValidationComplete: 'Validation complete',
 };
 
 export default translations;

--- a/src/pages/LogAction.js
+++ b/src/pages/LogAction.js
@@ -129,12 +129,13 @@ const LogAction = ({ user }) => {
         alignItems="center"
         textAlign="center"
         flexDirection="column"
+        paddingBottom="3rem"
       >
         <Box
           display="flex"
           justifyContent="flex-start"
-          width="100%"
           margin="-0.75em 0 0.5em"
+          width="100%"
         >
           {activeStep === 1 && (
             <Typography


### PR DESCRIPTION
## Ticket(s)

* [TIG-425](https://app.clickup.com/t/9009201449/TIG-425)
* [TIG-401](https://app.clickup.com/t/9009201449/TIG-401)
* [TIG-402](https://app.clickup.com/t/9009201449/TIG-402)

## Description

This PR improves the consistency of container sizing and action button styling between each Log Action step. Also added dynamic screen-reader-friendly messaging via `aria` for the loading state on the validation step.

## Screenshots

**Improved button styling on Step 2:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/b8fc98ad-9dd2-43a7-b30b-38788caf7113)

**Cleaner loading state with (visually hidden) update text and consistent button styling:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/f55a4a7e-810e-4c47-9f48-9ab1add455be)

**Max-width, font size, and centering updated for larger screen buttons:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/2c386b72-63bc-412d-8e4b-f6dccdb303ff)

