### PR TITLE
TIG-549 makes sure that filters are updated when a different tab is s…

### DIFF
--- a/src/components/GlobalLeaderboard.js
+++ b/src/components/GlobalLeaderboard.js
@@ -104,7 +104,7 @@ const GlobalLeaderboard = () => {
       handleFilterSelection();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [groups, users, selectedFilter]);
+  }, [groups, users, selectedFilter, selectedTab]);
 
   //sets filter back to default (total co2) and sets page back to first page on tab change
   const handleTabChange = (e, newValue) => {


### PR DESCRIPTION
Add `selectedTab` to the dependency list of the useEffect that calls the filter function for users and groups.  

Filtered users are initially set to be undefined and are only updated when the filter function is called.  Because the selectedTab was not a part of the useEffect dependency, the filtered global users list was not updated and stayed as undefined when the tab was changed, producing a table with no results.