### PR TITLE
[TIG-498] Restore App test(s)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test:watch": "react-scripts test --watchAll=true",
+    "test:coverage": "react-scripts test --watchAll=false --coverage",
+    "test": "npm run test:watch",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,16 +1,26 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import { MockReduxStoreProvider } from './utils/mock-redux-store-provider';
+import {
+  MockReduxStoreProvider,
+  mockAuthReduxStore,
+} from './utils/mock-redux-store-provider';
 import { Box } from '@mui/material';
 import App from './App';
 
-const mockSignedOutState = 'signIn';
-const mockUpdateLoginState = jest.fn();
+// Mock window object native functions
+global.scrollTo = jest.fn();
 
-const MockLogin = (props) => <Box {...props} data-testid="login-view" />;
+const MockLogin = (props) => <Box {...props} data-testid="login" />;
+const MockPageContainer = (props) => (
+  <Box {...props} data-testid="page-container" />
+);
 
 jest.mock('./components/authentication/Login_material', () => (props) => (
   <MockLogin {...props} />
+));
+
+jest.mock('./views/pageContainer/PageContainer', () => (props) => (
+  <MockPageContainer {...props} />
 ));
 
 jest.mock('./components/contexts/ContentTranslationsContext', () => ({
@@ -24,15 +34,25 @@ jest.mock('./services/translations', () => ({
 }));
 
 describe('App', () => {
-  it('renders Login view when user is not authenticated', () => {
-    render(
-      <MockReduxStoreProvider>
-        <App
-          loginState={mockSignedOutState}
-          updateLoginState={mockUpdateLoginState}
-        />
-      </MockReduxStoreProvider>
-    );
-    expect(screen.getByTestId('login-view')).toBeInTheDocument();
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders Login when user is not authenticated', () => {
+    render(<App />, { wrapper: MockReduxStoreProvider });
+    expect(screen.getByTestId('login')).toBeInTheDocument();
+  });
+
+  it('renders PageContainer when user is authenticated', () => {
+    render(<App />, {
+      wrapper: (props) => (
+        <MockReduxStoreProvider {...props} store={mockAuthReduxStore} />
+      ),
+    });
+    expect(screen.getByTestId('page-container')).toBeInTheDocument();
   });
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,38 @@
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
+import { MockReduxStoreProvider } from './utils/mock-redux-store-provider';
+import { Box } from '@mui/material';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+const mockSignedOutState = 'signIn';
+const mockUpdateLoginState = jest.fn();
+
+const MockLogin = (props) => <Box {...props} data-testid="login-view" />;
+
+jest.mock('./components/authentication/Login_material', () => (props) => (
+  <MockLogin {...props} />
+));
+
+jest.mock('./components/contexts/ContentTranslationsContext', () => ({
+  useContentTranslationsContext: () => ({
+    setContentTranslations: jest.fn(),
+  }),
+}));
+
+jest.mock('./services/translations', () => ({
+  getAllTranslations: () => ({}),
+}));
+
+describe('App', () => {
+  it('renders Login view when user is not authenticated', () => {
+    render(
+      <MockReduxStoreProvider>
+        <App
+          loginState={mockSignedOutState}
+          updateLoginState={mockUpdateLoginState}
+        />
+      </MockReduxStoreProvider>
+    );
+    expect(screen.getByTestId('login-view')).toBeInTheDocument();
+  });
 });

--- a/src/components/logAction/ActionFact.js
+++ b/src/components/logAction/ActionFact.js
@@ -18,7 +18,9 @@ import { useActionDetailsContext } from '../../hooks/use-action-details-context'
 import { useLanguageContext } from '../contexts/LanguageContext';
 import translations from '../../localization/en';
 
-Modal.setAppElement('#root');
+if (document.getElementById('root')) {
+  Modal.setAppElement('#root');
+}
 
 const ActionFact = ({
   setQuiz,

--- a/src/utils/mock-redux-store-provider.js
+++ b/src/utils/mock-redux-store-provider.js
@@ -1,13 +1,29 @@
 import * as React from 'react';
-import { applyMiddleware, createStore } from 'redux';
+import { createStore, combineReducers } from 'redux';
 import { Provider } from 'react-redux';
-import thunk from 'redux-thunk';
-import reducers from '../reducers';
+import loginReducer from '../reducers/loginReducer';
+import appStateReducer from '../reducers/appStateReducer';
 
-const mockReduxStore = createStore(reducers, applyMiddleware(thunk));
+export const mockInitialReduxStore = createStore(
+  combineReducers({
+    loginState: loginReducer,
+    appState: appStateReducer,
+  })
+);
 
-export const MockReduxStoreProvider = ({ children, ...props }) => (
-  <Provider store={mockReduxStore} {...props}>
+export const mockAuthReduxStore = createStore(
+  combineReducers({
+    loginState: () => ({ currentState: 'signedIn' }),
+    appState: appStateReducer,
+  })
+);
+
+export const MockReduxStoreProvider = ({
+  children,
+  store = mockInitialReduxStore,
+  ...props
+}) => (
+  <Provider store={store} {...props}>
     {children}
   </Provider>
 );

--- a/src/utils/mock-redux-store-provider.js
+++ b/src/utils/mock-redux-store-provider.js
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { applyMiddleware, createStore } from 'redux';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import reducers from '../reducers';
+
+const mockReduxStore = createStore(reducers, applyMiddleware(thunk));
+
+export const MockReduxStoreProvider = ({ children, ...props }) => (
+  <Provider store={mockReduxStore} {...props}>
+    {children}
+  </Provider>
+);


### PR DESCRIPTION
## Description

* [ClickUp ticket](https://app.clickup.com/t/9009201449/TIG-498)

This PR updates the `App.test.js` file's unit tests to mock the Redux store, hooks, and sub-components in order to test the non-auth vs authenticated user rendering behaviour. Also adds a redux store mock provider, which will very likely come in handy for future tests.

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/6e7b66dc-612c-4d5c-b31f-f05e03920a59)

Additionally, this adds an optional `test:coverage` script to the `package.json`, which tells us just how far we have to go:

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/d23c9dc9-cc43-4913-b91c-d12856fc0f95)

## Testing

* Pull down the branch
* Run `npm install` from the root
* Run `npm test` and wait (~5 secs) for it to complete
* Cancel the test watch process
* Run `npm test:coverage` and wait (~60 secs) for it to complete and output results