### PR TITLE
[TIG-570] Donut charts rendering

### DIFF
--- a/src/components/UserStatsCharts.js
+++ b/src/components/UserStatsCharts.js
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { useUserStats } from '../hooks/use-user-stats';
+import { Box, Typography } from '@mui/material';
+import { Doughnut } from 'react-chartjs-2';
+import useTranslation from './customHooks/translations';
+
+const chartHeight = '6.25rem';
+const chartWidth = '8.5rem';
+const chartFullWidth = '12.5rem';
+
+const chartOuterStyles = {
+  flex: `0 0 ${chartWidth}`,
+  position: 'relative',
+  overflow: 'visible',
+  height: chartHeight,
+  width: chartWidth,
+};
+
+const chartInnerStyles = {
+  height: chartHeight,
+  width: chartFullWidth,
+  position: 'absolute',
+  top: '-0.5rem',
+  left: '0',
+};
+
+const getDoughnutOptions = (title, displayTitle) => ({
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      display: false,
+    },
+    title: {
+      display: displayTitle,
+      text: title,
+      position: 'top',
+      color: '#eee',
+      font: {
+        size: 12,
+        weight: 'normal',
+      },
+    },
+  },
+});
+
+export const UserStatsCharts = ({ group }) => {
+  const { statsArray } = useUserStats(group);
+  const translation = useTranslation();
+
+  if (!statsArray) {
+    return (
+      <Typography variant="h3" component="p">
+        Log actions to see where you rank amongst your group!
+      </Typography>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'flex-end',
+        alignItems: 'flex-start',
+      }}
+    >
+      {statsArray.map(({ groupTotal, contribution, title }) => (
+        <Box key={title} sx={chartOuterStyles}>
+          <Box sx={chartInnerStyles}>
+            <Doughnut
+              data={{
+                labels: [
+                  translation.allOtherMembers,
+                  translation.myContribution,
+                ],
+                datasets: [
+                  {
+                    data: [groupTotal, contribution],
+                    backgroundColor: ['#808080', '#91C788'],
+                  },
+                ],
+              }}
+              options={getDoughnutOptions(
+                translation[title],
+                !(contribution === 0 && groupTotal === 0)
+              )}
+              height={300}
+              width={600}
+            />
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+};

--- a/src/components/groupProfile/GroupPageLeaderboard.js
+++ b/src/components/groupProfile/GroupPageLeaderboard.js
@@ -76,7 +76,7 @@ const GroupPageLeaderboard = ({ currentGroup, groupMembers, userId, user }) => {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(5);
   const [userStats, setUserStats] = useState();
-  const [donutChartsData, setDonutChartsData] = useState();
+  const [donutChartsData, setDonutChartsData] = useState([]);
   const [userContributionPercentages, setUserContributionPercentages] =
     useState();
 
@@ -312,6 +312,7 @@ const GroupPageLeaderboard = ({ currentGroup, groupMembers, userId, user }) => {
                   ) : (
                     donutChartsData.map((data) => (
                       <UserContributionDonutChart
+                        key={data.title}
                         data={data}
                         displayTitles={true}
                       />
@@ -410,7 +411,7 @@ const GroupPageLeaderboard = ({ currentGroup, groupMembers, userId, user }) => {
                     key={member.user_id}
                     sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
                     className={
-                      userId === member.user_id && 'currentGroupOrUser'
+                      userId === member.user_id ? 'currentGroupOrUser' : ''
                     }
                   >
                     <TableCell

--- a/src/components/groupProfile/GroupPageLeaderboard.js
+++ b/src/components/groupProfile/GroupPageLeaderboard.js
@@ -32,10 +32,10 @@ import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { styled } from '@mui/material/styles';
 import { SortLeaderboard } from '../SortLeaderboard';
-import UserContributionDonutChart from '../UserContributionDonutChart';
 import { useNavigate } from 'react-router-dom';
 import useTranslation from '../customHooks/translations';
 import { CurrentPlaceNumbers } from '../CurrentPlaceNumbers';
+import { UserStatsCharts } from '../UserStatsCharts';
 
 const StyledTableBody = styled(TableBody)`
   td {
@@ -76,7 +76,6 @@ const GroupPageLeaderboard = ({ currentGroup, groupMembers, userId, user }) => {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(5);
   const [userStats, setUserStats] = useState();
-  const [donutChartsData, setDonutChartsData] = useState([]);
   const [userContributionPercentages, setUserContributionPercentages] =
     useState();
 
@@ -86,30 +85,6 @@ const GroupPageLeaderboard = ({ currentGroup, groupMembers, userId, user }) => {
 
   useEffect(() => {
     if (userStats) {
-      const donutData = [
-        {
-          groupTotal: currentGroup.total_co2 - userStats.total_co2,
-          contribution: userStats.total_co2,
-          title: translation.totalCO2,
-        },
-        {
-          groupTotal: currentGroup.weekly_co2 - userStats.weekly_co2,
-          contribution: userStats.weekly_co2,
-          title: translation.weeklyCO2,
-        },
-        {
-          groupTotal: currentGroup.total_points - userStats.total_points,
-          contribution: userStats.total_points,
-          title: translation.totalPoints,
-        },
-        {
-          groupTotal: currentGroup.weekly_points - userStats.weekly_points,
-          contribution: userStats.weekly_points,
-          title: translation.weeklyPoints,
-        },
-      ];
-      setDonutChartsData(donutData);
-
       const percentageData = [
         {
           title: translation.totalCO2,
@@ -279,6 +254,7 @@ const GroupPageLeaderboard = ({ currentGroup, groupMembers, userId, user }) => {
                   alignItems: 'center',
                   justifyContent: 'space-between',
                   flexDirection: hideCharts ? 'column' : 'row',
+                  flexWrap: 'wrap',
                 }}
               >
                 <CurrentPlaceNumbers
@@ -310,13 +286,7 @@ const GroupPageLeaderboard = ({ currentGroup, groupMembers, userId, user }) => {
                       </AccordionDetails>
                     </Accordion>
                   ) : (
-                    donutChartsData.map((data) => (
-                      <UserContributionDonutChart
-                        key={data.title}
-                        data={data}
-                        displayTitles={true}
-                      />
-                    ))
+                    <UserStatsCharts group={currentGroup} />
                   )}
                 </Box>
               </Box>

--- a/src/hooks/use-user-stats.js
+++ b/src/hooks/use-user-stats.js
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+import { API } from 'aws-amplify';
+import { getAllGroups, getUserStatsForGroup } from '../graphql/queries';
+import { useUserInfoContext } from './use-user-info-context';
+
+const getStatsArray = (userStats, group) => {
+  if (!userStats) return null;
+
+  const { totalCo2, weeklyCo2, totalPoints, weeklyPoints } = userStats;
+  if (!totalCo2 && !weeklyCo2 && !totalPoints && !weeklyPoints) {
+    return null;
+  }
+
+  return [
+    {
+      groupTotal: group.total_co2 - totalCo2,
+      contribution: totalCo2,
+      title: 'totalCO2',
+    },
+    {
+      groupTotal: group.weekly_co2 - weeklyCo2,
+      contribution: weeklyCo2,
+      title: 'weeklyCO2',
+    },
+    {
+      groupTotal: group.total_points - totalPoints,
+      contribution: totalPoints,
+      title: 'totalPoints',
+    },
+    {
+      groupTotal: group.weekly_points - weeklyPoints,
+      contribution: weeklyPoints,
+      title: 'weeklyPoints',
+    },
+  ];
+};
+
+export const useUserStats = (group = null) => {
+  const { user } = useUserInfoContext();
+  const [userStats, setUserStats] = useState(null);
+  const [groups, setGroups] = useState(null);
+
+  const userId = user?.user_id | null;
+  const groupId = group?.group_id | null;
+
+  useEffect(() => {
+    const getGroups = async () => {
+      const res = await API.graphql({
+        query: getAllGroups,
+      });
+      setGroups(res.data.getAllGroups);
+    };
+
+    if (!groups) {
+      getGroups();
+    }
+  }, [groups]);
+
+  useEffect(() => {
+    const getUserStats = async () => {
+      const res = await API.graphql({
+        query: getUserStatsForGroup,
+        variables: { user_id: userId, group_id: groupId },
+      });
+      setUserStats(res.data.getUserStatsForGroup);
+    };
+
+    if (groupId && userId && !userStats) {
+      getUserStats();
+    }
+  }, [groupId, userId, userStats]);
+
+  const userStatsResolved = {
+    totalCo2: userStats?.total_co2 | user?.total_co2 | null,
+    weeklyCo2: userStats?.weekly_co2 | user?.weekly_co2 | null,
+    totalPoints: userStats?.total_points | user?.total_points | null,
+    weeklyPoints: userStats?.weekly_points | user?.weekly_points | null,
+  };
+
+  return {
+    userStats: userStatsResolved,
+    statsArray: getStatsArray(userStatsResolved, group),
+  };
+};


### PR DESCRIPTION
## Ticket

* [TIG-570](https://app.clickup.com/t/9009201449/TIG-570)

## Description

This PR fixes the donut stats rendering for users viewing their group(s) leaderboard table. Because the request for a user's points per group was returning `null` values, we have a fallback here to grab the user's total contributions from their data already stored in React context. 

There are also some styling tweaks in here to group the charts closer together and allow them to render more cleanly on smaller screens without crushing other content or overflowing past the edge of the page layout. 

## Screenshots

**User stat charts rendering alongside their group rank with one of the popup tooltips visible:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/7eefd8bd-8f58-4cb3-9ba0-d416795c57c2)

**Other table tab rendering at the same width, thanks to flex sizing of the stats charts:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/0dd1d83b-6af5-4263-990c-e75777a19f61)

**Fallback view if no user stats are available:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/ea649bd9-cd15-4f27-9a12-4c9c9c9971ef)

