### PR TITLE
[TIG-500] Page level tests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -123,7 +123,7 @@ function App(props) {
 
 App.propTypes = {
   ...BaseComponent,
-  loginState: PropTypes.object,
+  loginState: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   updateLoginState: PropTypes.func.isRequired,
 };
 

--- a/src/components/GlobalLeaderboard.js
+++ b/src/components/GlobalLeaderboard.js
@@ -27,7 +27,9 @@ import { useNavigate } from 'react-router-dom';
 import { SortLeaderboard } from './SortLeaderboard';
 import { useLanguageContext } from '../components/contexts/LanguageContext';
 
-import useTranslation from ".//customHooks/translations";
+import useTranslation from './/customHooks/translations';
+
+export const tabKeys = ['globalGroups', 'globalUsers'];
 
 const StyledTableBody = styled(TableBody)`
   td {
@@ -48,19 +50,23 @@ const StyledTableBody = styled(TableBody)`
 const GlobalLeaderboard = () => {
   const navigate = useNavigate();
   const translation = useTranslation();
-  const tabs = useMemo(() => [
-    translation.globalGroups,
-    translation.globalUsers,
-  ], [translation.globalGroups, translation.globalUsers]);
-  const filters = useMemo(() => [
+  const filters = useMemo(
+    () => [
     { name: translation.totalCO2Saved, property: 'total_co2' },
     { name: translation.weeklyCO2Saved, property: 'weekly_co2' },
     { name: translation.totalPoints, property: 'total_points' },
     { name: translation.weeklyPoints, property: 'weekly_points' },
-  ], [translation.totalCO2Saved, translation.totalPoints, translation.weeklyCO2Saved, translation.weeklyPoints]);
+    ],
+    [
+      translation.totalCO2Saved,
+      translation.totalPoints,
+      translation.weeklyCO2Saved,
+      translation.weeklyPoints,
+    ]
+  );
   const [groups, setGroups] = useState();
   const [users, setUsers] = useState();
-  const [selectedTab, setSelectedTab] = useState(tabs[0]);
+  const [selectedTab, setSelectedTab] = useState(tabKeys[0]);
   const [selectedFilter, setSelectedFilter] = useState(filters[0]);
   const [filteredGroups, setFilteredGroups] = useState();
   const [filteredUsers, setFilteredUsers] = useState();
@@ -77,9 +83,9 @@ const GlobalLeaderboard = () => {
   let emptyRows =
     page <= 0
       ? 0
-      : selectedTab === tabs[0]
+      : selectedTab === tabKeys[0]
         ? Math.max(0, (1 + page) * rowsPerPage - groups.length)
-        : selectedTab === tabs[1]
+      : selectedTab === tabKeys[1]
           ? Math.max(0, (1 + page) * rowsPerPage - users.length)
           : 0;
 
@@ -94,9 +100,9 @@ const GlobalLeaderboard = () => {
     };
 
     getTableData();
-    setSelectedTab(tabs[0]);
+    setSelectedTab(tabKeys[0]);
     setSelectedFilter(filters[0]);
-  }, [tabs, filters, language]);
+  }, [filters, language]);
 
   //filters groups when group state is initially set, filters groups and group members every time a new filter is selected
   useEffect(() => {
@@ -127,7 +133,7 @@ const GlobalLeaderboard = () => {
   const handleFilterSelection = () => {
     const propertySelected = selectedFilter.property;
     //if Global Group tab is selected, apply the selected filter to all groups
-    if (selectedTab === tabs[0] && groups) {
+    if (selectedTab === tabKeys[0] && groups) {
       //make a mutable copy of the groups array, sort that array and update the in state version of groups
       let groupsArrayCopy = [...groups];
       let sortedByFilter = groupsArrayCopy.sort(
@@ -136,7 +142,7 @@ const GlobalLeaderboard = () => {
       setFilteredGroups(sortedByFilter);
     }
     //if Group Members tab is selected, apply the selected filter to all users
-    if (selectedTab === tabs[1] && users) {
+    if (selectedTab === tabKeys[1] && users) {
       //make a mutable copy of the users array, sort that array and update the in state version of users
       let usersArrayCopy = [...users];
       let sortedByFilter = usersArrayCopy.sort(
@@ -164,7 +170,10 @@ const GlobalLeaderboard = () => {
         <TableContainer component={Paper} sx={{ mt: '1em', backgroundColor: '#131516' }}>
           <Table stickyHeader aria-label="group leaderboard">
             <caption>
-              {translation.formatString(translation.leaderboardDisplaying, { tab: selectedTab })}{selectedFilter.name}
+              {translation.formatString(translation.leaderboardDisplaying, {
+                tab: translation[selectedTab],
+              })}
+              {selectedFilter.name}
             </caption>
             <TableHead sx={{ mt: '1em', backgroundColor: '#131516' }}>
               <TableRow sx={{ position: 'relative', zIndex: '1' }}>
@@ -178,7 +187,7 @@ const GlobalLeaderboard = () => {
             </TableHead>
             <StyledTableBody>
               {/* if Global Groups tab is selected, display all groups data in table body*/}
-              {selectedTab === tabs[0] &&
+              {selectedTab === tabKeys[0] &&
                 filteredGroups &&
                 (rowsPerPage > 0
                   ? filteredGroups.slice(
@@ -232,7 +241,7 @@ const GlobalLeaderboard = () => {
                 ))}
 
               {/* if Global Users tab is selected, display all user data in table body*/}
-              {selectedTab === tabs[1] &&
+              {selectedTab === tabKeys[1] &&
                 filteredUsers &&
                 (rowsPerPage > 0
                   ? filteredUsers.slice(
@@ -278,7 +287,7 @@ const GlobalLeaderboard = () => {
           </Table>
         </TableContainer>
         {/* render the correct pagination options for each table */}
-        {selectedTab === tabs[0] && groups && (
+        {selectedTab === tabKeys[0] && groups && (
           <TablePagination
             rowsPerPageOptions={[5, 10]}
             component="div"
@@ -297,7 +306,7 @@ const GlobalLeaderboard = () => {
             }
           />
         )}
-        {selectedTab === tabs[1] && users && (
+        {selectedTab === tabKeys[1] && users && (
           <TablePagination
             rowsPerPageOptions={[5, 10]}
             component="div"
@@ -364,7 +373,11 @@ const GlobalLeaderboard = () => {
               </Menu>
             </Box>
           </Box>
-          <TabContext value={tabs.indexOf(selectedTab) !== -1 ? selectedTab : tabs[0]}>
+          <TabContext
+            value={
+              tabKeys.indexOf(selectedTab) !== -1 ? selectedTab : tabKeys[0]
+            }
+          >
             <Box
               sx={{
                 borderTop: 1,
@@ -389,19 +402,17 @@ const GlobalLeaderboard = () => {
                   borderBottomColor: { xs: 'divider', sm: 'transparent' },
                 }}
               >
-                <Tab label={translation.globalGroups} value={tabs[0]} id={tabs[0]} />
-                <Tab label={translation.globalUsers} value={tabs[1]} id={tabs[1]} />
+                <Tab label={translation[tabKeys[0]]} value={tabKeys[0]} />
+                <Tab label={translation[tabKeys[1]]} value={tabKeys[1]} />
               </TabList>
               <TabPanel
-                value={tabs[0]}
-                aria-labelledby={tabs[0]}
+                value={tabKeys[0]}
                 sx={{ width: '100%', padding: { xs: '0', sm: '1.5em' } }}
               >
                 {renderTable()}
               </TabPanel>
               <TabPanel
-                value={tabs[1]}
-                aria-labelledby={tabs[1]}
+                value={tabKeys[1]}
                 sx={{ width: '100%', padding: { xs: '0', sm: '1.5em' } }}
               >
                 {renderTable()}

--- a/src/components/UserActions.js
+++ b/src/components/UserActions.js
@@ -135,7 +135,7 @@ const UserActions = ({ databaseUser, setUser, userType }) => {
     } else {
       return (
         <Box sx={{ textAlign: 'center' }}>
-          <Typography variant="subtitle2">
+          <Typography component="p" variant="subtitle2">
             {translation.noValidatedActions}
           </Typography>
         </Box>
@@ -184,7 +184,7 @@ const UserActions = ({ databaseUser, setUser, userType }) => {
     } else {
       return (
         <Box sx={{ textAlign: 'center' }}>
-          <Typography variant="subtitle2">
+          <Typography component="p" variant="subtitle2">
             {translation.noUnvalidatedActions}
           </Typography>
         </Box>
@@ -233,7 +233,7 @@ const UserActions = ({ databaseUser, setUser, userType }) => {
     } else {
       return (
         <Box sx={{ textAlign: 'center' }}>
-          <Typography variant="subtitle2">
+          <Typography component="p" variant="subtitle2">
             {translation.noFailedActions}
           </Typography>
         </Box>

--- a/src/components/adminDashboard/BarChart.js
+++ b/src/components/adminDashboard/BarChart.js
@@ -107,8 +107,11 @@ const BarChart = ({ allSubmittedActions }) => {
           mb: '1.5em',
         }}
       >
-        <Typography variant="subtitle2">
-          {translation.formatString(translation.actionsSubmittedFilter, selectedFilter)}
+        <Typography component="p" variant="subtitle2">
+          {translation.formatString(
+            translation.actionsSubmittedFilter,
+            selectedFilter
+          )}
         </Typography>
         <Box
           sx={{

--- a/src/components/adminDashboard/Dashboard.js
+++ b/src/components/adminDashboard/Dashboard.js
@@ -112,7 +112,10 @@ const Dashboard = () => {
         <Grid item xs={12} md={3}>
           {allUsers && (
             <StyledPaper sx={{ display: 'flex', flexDirection: 'column' }}>
-              <Typography variant="h7"> {translation.totalUsers}</Typography>
+              <Typography component="p" variant="h7">
+                {' '}
+                {translation.totalUsers}
+              </Typography>
               <Typography
                 variant="h2"
                 sx={{
@@ -133,7 +136,10 @@ const Dashboard = () => {
             <StyledPaper
               sx={{ display: 'flex', flexDirection: 'column', mt: '1em' }}
             >
-              <Typography variant="h7"> {translation.totalGroups}</Typography>
+              <Typography component="p" variant="h7">
+                {' '}
+                {translation.totalGroups}
+              </Typography>
               <Typography
                 variant="h2"
                 sx={{
@@ -213,7 +219,7 @@ const Dashboard = () => {
                 justifyContent: 'center',
               }}
             >
-              <Typography variant="h7">
+              <Typography component="p" variant="h7">
                 {' '}
                 {translation.totalActionsSubmitted}
               </Typography>

--- a/src/components/adminDashboard/LineChart.js
+++ b/src/components/adminDashboard/LineChart.js
@@ -111,7 +111,7 @@ const LineChart = ({ allSubmittedActions }) => {
           mb: '1.5em',
         }}
       >
-        <Typography variant="subtitle2">
+        <Typography component="p" variant="subtitle2">
           {translation.formatString(translation.co2SavedDuring, selectedFilter)}
         </Typography>
         <Box

--- a/src/components/validateActions/ActionNameSearchBar.js
+++ b/src/components/validateActions/ActionNameSearchBar.js
@@ -116,7 +116,12 @@ const ActionNameSearchBar = ({
 
   return (
     <>
-      {!allActionTypes && <LinearProgress sx={{ mt: '3em' }} />}
+      {!allActionTypes && (
+        <LinearProgress
+          aria-label="loading actions search"
+          sx={{ mt: '3em' }}
+        />
+      )}
       {allActionTypes && (
         <>
           <Autocomplete

--- a/src/components/validateActions/GroupNameSearchBar.js
+++ b/src/components/validateActions/GroupNameSearchBar.js
@@ -108,7 +108,9 @@ const GroupNameSearchBar = ({
 
   return (
     <>
-      {!groupsOwnedByUser && <LinearProgress sx={{ mt: '3em' }} />}
+      {!groupsOwnedByUser && (
+        <LinearProgress aria-label="loading groups search" sx={{ mt: '3em' }} />
+      )}
       {groupsOwnedByUser && (
         <>
           <Autocomplete
@@ -187,6 +189,7 @@ const GroupNameSearchBar = ({
         {((allActionsToValidate && allActionsToValidate.length === 0) ||
           (filteredActions && filteredActions.length === 0)) && (
           <Typography
+            component="p"
             variant="subtitle2"
             sx={{ textAlign: 'center', mt: '1em' }}
           >

--- a/src/components/validateActions/MyGroupsPanel.js
+++ b/src/components/validateActions/MyGroupsPanel.js
@@ -46,7 +46,9 @@ const MyGroupsPanel = ({ user }) => {
           flexDirection: { xs: 'column', md: 'row' },
         }}
       >
-        <Typography variant="subtitle2">{translation.searchByC}</Typography>
+        <Typography component="p" variant="subtitle2">
+          {translation.searchByC}
+        </Typography>
         <ToggleButtonGroup
           color="primary"
           value={filterOption}

--- a/src/pages/AccountSettings.js
+++ b/src/pages/AccountSettings.js
@@ -48,6 +48,7 @@ const AccountSettings = () => {
                 >
                   <Avatar
                     variant="rounded"
+                    alt=""
                     src={user.avatar + '?' + new Date()}
                     sx={{
                       width: 120,

--- a/src/pages/AccountSettings.test.js
+++ b/src/pages/AccountSettings.test.js
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AccountSettings from './AccountSettings';
+import { mockUser } from '../utils/jest-mock-utils';
+
+jest.mock('aws-amplify', () => ({
+  API: {
+    graphql: () => ({
+      data: {
+        getAllSubmittedActionsForUser: [],
+        getSingleUser: {},
+      },
+    }),
+  },
+}));
+
+jest.mock('../hooks/use-user-info-context', () => ({
+  useUserInfoContext: () => ({
+    user: mockUser,
+    setUser: jest.fn(),
+  }),
+}));
+
+describe('AccountSettings', () => {
+  it('renders main heading with user avatar, name, and email', async () => {
+    render(<AccountSettings />);
+
+    // We're using the promise-based `findBy` util here because of the post-init async changes
+    // caused by API requests, hooks, and other dependencies within the component's children.
+    // This is all to avoid the dreaded `act` error in React tests:
+    // https://davidwcai.medium.com/react-testing-library-and-the-not-wrapped-in-act-errors-491a5629193b
+
+    const heading = await screen.findByRole('heading', {
+      level: 1,
+      name: /my account/i,
+    });
+    expect(heading).toBeInTheDocument();
+    expect(screen.getByText(mockUser.name)).toBeInTheDocument();
+    expect(screen.getByText(mockUser.email)).toBeInTheDocument();
+    expect(screen.getByRole('img').getAttribute('src')).toContain(
+      mockUser.avatar
+    );
+  });
+
+  it('renders edit info button which opens edit modal', async () => {
+    render(<AccountSettings />);
+
+    const button = await screen.findByRole('button', { name: /edit info/i });
+    expect(button).toBeInTheDocument();
+
+    userEvent.click(button);
+
+    const dialog = await screen.findByRole('dialog');
+    const heading = await screen.findByRole('heading', {
+      level: 2,
+      name: /edit account information/i,
+    });
+    expect(dialog).toBeInTheDocument();
+    expect(heading).toBeInTheDocument();
+  });
+
+  it('renders actions heading and tabs', async () => {
+    render(<AccountSettings />);
+
+    const tabs = await screen.findAllByRole('tab');
+    const heading = await screen.findByRole('heading', {
+      level: 2,
+      name: /my actions/i,
+    });
+    expect(heading).toBeInTheDocument();
+    expect(tabs.length).toBe(3);
+    expect(tabs[0]).toHaveTextContent(/validated/i);
+  });
+});

--- a/src/pages/AccountSettings.test.js
+++ b/src/pages/AccountSettings.test.js
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
-import { UserInfoContext } from '../hooks/use-user-info-context';
-import { mockUser } from '../utils/jest-mock-utils';
+import { mockUser, renderWithAppContext } from '../utils/jest-mock-utils';
 import AccountSettings from './AccountSettings';
 
 jest.mock('aws-amplify', () => ({
@@ -17,15 +16,9 @@ jest.mock('aws-amplify', () => ({
   },
 }));
 
-const AccountSettingsWithProviders = (props) => (
-  <UserInfoContext.Provider value={{ user: mockUser, setUser: jest.fn() }}>
-    <AccountSettings {...props} />
-  </UserInfoContext.Provider>
-);
-
 describe('AccountSettings', () => {
   it('renders main heading with user avatar, name, and email', async () => {
-    const { container } = render(<AccountSettingsWithProviders />);
+    const { container } = renderWithAppContext(<AccountSettings />);
 
     // We're using the promise-based `findBy` util here because of the post-init async changes
     // caused by API requests, hooks, and other dependencies within the component's children.
@@ -48,7 +41,7 @@ describe('AccountSettings', () => {
   });
 
   it('renders edit info button which opens edit modal', async () => {
-    render(<AccountSettingsWithProviders />);
+    renderWithAppContext(<AccountSettings />);
 
     const button = await screen.findByRole('button', { name: /edit info/i });
     expect(button).toBeInTheDocument();
@@ -65,7 +58,7 @@ describe('AccountSettings', () => {
   });
 
   it('renders actions heading and tabs', async () => {
-    render(<AccountSettingsWithProviders />);
+    renderWithAppContext(<AccountSettings />);
 
     const tabs = await screen.findAllByRole('tab');
     const heading = await screen.findByRole('heading', {

--- a/src/pages/Actions.test.js
+++ b/src/pages/Actions.test.js
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { UserInfoContext } from '../hooks/use-user-info-context';
+import { mockUser } from '../utils/jest-mock-utils';
+import Actions from './Actions';
+
+jest.mock('aws-amplify', () => ({
+  API: {
+    graphql: () => ({
+      data: {
+        getAllSubmittedActionsForUser: [],
+      },
+    }),
+  },
+}));
+
+const ActionsWithProviders = (props) => (
+  <UserInfoContext.Provider value={{ user: mockUser }}>
+    <Actions {...props} />
+  </UserInfoContext.Provider>
+);
+
+describe('Actions', () => {
+  it('renders main heading and passes basic a11y validation', async () => {
+    const { container } = render(<ActionsWithProviders />);
+
+    const heading = await screen.findByRole('heading', {
+      level: 1,
+      name: /my actions/i,
+    });
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+    expect(heading).toBeInTheDocument();
+  });
+
+  it('renders actions tabs', async () => {
+    render(<ActionsWithProviders />);
+
+    const tabs = await screen.findAllByRole('tab');
+
+    expect(tabs.length).toBe(3);
+    expect(tabs[0]).toHaveTextContent(/validated/i);
+  });
+});

--- a/src/pages/Actions.test.js
+++ b/src/pages/Actions.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
-import { UserInfoContext } from '../hooks/use-user-info-context';
-import { mockUser } from '../utils/jest-mock-utils';
+import { renderWithAppContext } from '../utils/jest-mock-utils';
 import Actions from './Actions';
 
 jest.mock('aws-amplify', () => ({
@@ -15,15 +14,9 @@ jest.mock('aws-amplify', () => ({
   },
 }));
 
-const ActionsWithProviders = (props) => (
-  <UserInfoContext.Provider value={{ user: mockUser }}>
-    <Actions {...props} />
-  </UserInfoContext.Provider>
-);
-
 describe('Actions', () => {
   it('renders main heading and passes basic a11y validation', async () => {
-    const { container } = render(<ActionsWithProviders />);
+    const { container } = renderWithAppContext(<Actions />);
 
     const heading = await screen.findByRole('heading', {
       level: 1,
@@ -36,7 +29,7 @@ describe('Actions', () => {
   });
 
   it('renders actions tabs', async () => {
-    render(<ActionsWithProviders />);
+    renderWithAppContext(<Actions />);
 
     const tabs = await screen.findAllByRole('tab');
 

--- a/src/pages/AdminDashboard.test.js
+++ b/src/pages/AdminDashboard.test.js
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { MemoryRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import AdminDashboard from './AdminDashboard';
+
+jest.mock('aws-amplify', () => ({
+  API: {
+    graphql: () => ({
+      data: {
+        getAllActions: [],
+        getAllGroups: [],
+        getAllSubmittedActions: [],
+        getAllUsers: [],
+      },
+    }),
+  },
+}));
+
+jest.mock('react-chartjs-2', () => ({
+  Bar: (props) => <div {...props} />,
+  Doughnut: (props) => <div {...props} />,
+}));
+
+const AdminDashboardWithProviders = (props) => (
+  <MemoryRouter>
+    <AdminDashboard {...props} />
+  </MemoryRouter>
+);
+
+describe('AdminDashboard', () => {
+  it('renders menu tabs with first (dashboard) selected', async () => {
+    const { container } = render(<AdminDashboardWithProviders />);
+
+    const tabs = await screen.findAllByRole('tab');
+    const heading = await screen.findByRole('heading', {
+      level: 1,
+      name: /admin dashboard/i,
+    });
+    const results = await axe(container);
+
+    expect(tabs.length).toBe(4);
+    expect(heading).toBeInTheDocument();
+    expect(results).toHaveNoViolations();
+    expect(tabs[0]).toHaveTextContent(/dashboard/i);
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('selecting other tabs renders expected content', async () => {
+    render(<AdminDashboardWithProviders />);
+
+    const tabs = await screen.findAllByRole('tab');
+
+    expect(tabs[2]).toHaveTextContent(/manage actions/i);
+
+    userEvent.click(tabs[2]);
+
+    const heading = await screen.findByRole('heading', {
+      level: 1,
+      name: /select an action to view and edit/i,
+    });
+
+    expect(heading).toBeInTheDocument();
+    // expect(tabs[2]).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/src/pages/AdminDashboard.test.js
+++ b/src/pages/AdminDashboard.test.js
@@ -23,15 +23,9 @@ jest.mock('react-chartjs-2', () => ({
   Doughnut: (props) => <div {...props} />,
 }));
 
-const AdminDashboardWithProviders = (props) => (
-  <MemoryRouter>
-    <AdminDashboard {...props} />
-  </MemoryRouter>
-);
-
 describe('AdminDashboard', () => {
   it('renders menu tabs with first (dashboard) selected', async () => {
-    const { container } = render(<AdminDashboardWithProviders />);
+    const { container } = render(<AdminDashboard />, { wrapper: MemoryRouter });
 
     const tabs = await screen.findAllByRole('tab');
     const heading = await screen.findByRole('heading', {
@@ -48,7 +42,7 @@ describe('AdminDashboard', () => {
   });
 
   it('selecting other tabs renders expected content', async () => {
-    render(<AdminDashboardWithProviders />);
+    render(<AdminDashboard />, { wrapper: MemoryRouter });
 
     const tabs = await screen.findAllByRole('tab');
 
@@ -62,6 +56,6 @@ describe('AdminDashboard', () => {
     });
 
     expect(heading).toBeInTheDocument();
-    // expect(tabs[2]).toHaveAttribute('aria-selected', 'true');
+    expect(tabs[2]).toHaveAttribute('aria-selected', 'true');
   });
 });

--- a/src/pages/ValidateActions.js
+++ b/src/pages/ValidateActions.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Box, Typography, Tab } from '@mui/material';
 import TabContext from '@mui/lab/TabContext';
 import TabList from '@mui/lab/TabList';
@@ -11,22 +11,16 @@ import { useLanguageContext } from '../components/contexts/LanguageContext';
 import useTranslation from '../components/customHooks/translations';
 import { useUserInfoContext } from '../hooks/use-user-info-context';
 
+export const actionsTabKeys = [
+  'myGroups',
+  'validateActionsUsersWithoutGroupsTab',
+  'validateActionsAllUnvalidatedActionsTab',
+];
+
 const ValidateActions = () => {
   const { user, userType } = useUserInfoContext();
   const translation = useTranslation();
-  const tabs = useMemo(
-    () => [
-      translation.myGroups,
-      translation.validateActionsUsersWithoutGroupsTab,
-      translation.validateActionsAllUnvalidatedActionsTab,
-    ],
-    [
-      translation.myGroups,
-      translation.validateActionsAllUnvalidatedActionsTab,
-      translation.validateActionsUsersWithoutGroupsTab,
-    ]
-  );
-  const [selectedTab, setSelectedTab] = useState(tabs[0]);
+  const [selectedTab, setSelectedTab] = useState(actionsTabKeys[0]);
   const scrollableTabs = useMediaQuery((theme) => theme.breakpoints.down('sm'));
   const { language } = useLanguageContext();
 
@@ -35,8 +29,8 @@ const ValidateActions = () => {
   };
 
   useEffect(() => {
-    setSelectedTab(tabs[0]);
-  }, [tabs, language]);
+    setSelectedTab(actionsTabKeys[0]);
+  }, [language]);
 
   return (
     <>
@@ -49,7 +43,11 @@ const ValidateActions = () => {
       {userType &&
         (userType === 'Admin' ? (
           <TabContext
-            value={tabs.indexOf(selectedTab) !== -1 ? selectedTab : tabs[0]}
+            value={
+              actionsTabKeys.indexOf(selectedTab) !== -1
+                ? selectedTab
+                : actionsTabKeys[0]
+            }
           >
             <Box
               sx={{
@@ -70,24 +68,27 @@ const ValidateActions = () => {
                 variant={scrollableTabs ? 'scrollable' : 'fullWidth'}
                 centered={!scrollableTabs}
               >
-                <Tab label={translation.myGroups} value={tabs[0]} />
                 <Tab
-                  label={translation.validateActionsUsersWithoutGroupsTab}
-                  value={tabs[1]}
+                  label={translation[actionsTabKeys[0]]}
+                  value={actionsTabKeys[0]}
                 />
                 <Tab
-                  label={translation.validateActionsAllUnvalidatedActionsTab}
-                  value={tabs[2]}
+                  label={translation[actionsTabKeys[1]]}
+                  value={actionsTabKeys[1]}
+                />
+                <Tab
+                  label={translation[actionsTabKeys[2]]}
+                  value={actionsTabKeys[2]}
                 />
               </TabList>
             </Box>
-            <TabPanel value={tabs[0]}>
+            <TabPanel value={actionsTabKeys[0]}>
               <MyGroupsPanel user={user} />
             </TabPanel>
-            <TabPanel value={tabs[1]}>
+            <TabPanel value={actionsTabKeys[1]}>
               <UsersWithoutGroupPanel user={user} />
             </TabPanel>
-            <TabPanel value={tabs[2]}>
+            <TabPanel value={actionsTabKeys[2]}>
               <AllUnvalidatedActionsPanel user={user} />
             </TabPanel>
           </TabContext>

--- a/src/pages/ValidateActions.test.js
+++ b/src/pages/ValidateActions.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { renderWithAppContext } from '../utils/jest-mock-utils';
-import ValidateActions from './ValidateActions';
+import ValidateActions, { actionsTabKeys } from './ValidateActions';
 
 jest.mock('aws-amplify', () => ({
   API: {
@@ -16,7 +17,20 @@ jest.mock('aws-amplify', () => ({
 }));
 
 describe('ValidateActions', () => {
-  it('renders heading without tabs when user is not admin', async () => {
+  it('passes basic a11y validation', async () => {
+    const { container } = renderWithAppContext(<ValidateActions />, {}, true);
+
+    const heading = await screen.findByRole('heading', {
+      level: 1,
+      name: /validate actions/i,
+    });
+    const results = await axe(container);
+
+    expect(heading).toBeInTheDocument();
+    expect(results).toHaveNoViolations();
+  });
+
+  it('renders heading, search controls, actions messaging, and pagination', async () => {
     renderWithAppContext(<ValidateActions />);
 
     const heading = await screen.findByRole('heading', {
@@ -25,10 +39,37 @@ describe('ValidateActions', () => {
     });
 
     expect(heading).toBeInTheDocument();
-    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /group name/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /action name/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/there are no actions in need of validation/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('navigation', { name: /pagination navigation/i })
+    ).toBeInTheDocument();
   });
 
-  it('renders heading and tabs with My Groups selected when user is admin', async () => {
+  it('does not render actions tabs when user is not a group admin', async () => {
+    renderWithAppContext(<ValidateActions />);
+
+    const heading = await screen.findByRole('heading', {
+      level: 1,
+      name: /validate actions/i,
+    });
+
+    expect(heading).toBeInTheDocument();
+    expect(screen.queryAllByRole('tab').length).toBe(0);
+  });
+
+  it('renders actions tabs with My Groups selected when user is admin', async () => {
     renderWithAppContext(<ValidateActions />, {}, true);
 
     const heading = await screen.findByRole('heading', {
@@ -38,7 +79,7 @@ describe('ValidateActions', () => {
     const tabs = await screen.findAllByRole('tab');
 
     expect(heading).toBeInTheDocument();
-    expect(tabs.length).toBe(3);
+    expect(tabs.length).toBe(actionsTabKeys.length);
     expect(tabs[0]).toHaveTextContent(/my groups/i);
     expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
   });

--- a/src/pages/ValidateActions.test.js
+++ b/src/pages/ValidateActions.test.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithAppContext } from '../utils/jest-mock-utils';
+import ValidateActions from './ValidateActions';
+
+describe('ValidateActions', () => {
+  it('renders the page heading', async () => {
+    renderWithAppContext(<ValidateActions />);
+
+    const heading = await screen.findByRole('heading', {
+      level: 1,
+      name: /validate actions/i,
+    });
+
+    expect(heading).toBeInTheDocument();
+  });
+});

--- a/src/pages/ValidateActions.test.js
+++ b/src/pages/ValidateActions.test.js
@@ -3,8 +3,20 @@ import { screen } from '@testing-library/react';
 import { renderWithAppContext } from '../utils/jest-mock-utils';
 import ValidateActions from './ValidateActions';
 
+jest.mock('aws-amplify', () => ({
+  API: {
+    graphql: () => ({
+      data: {
+        getAllSubmittedActionsToValidate: [],
+        getAllSubmittedActionsOfUsersWithoutGroupToValidateForAdmin: [],
+        getAllSubmittedActionsToValidateForAdmin: [],
+      },
+    }),
+  },
+}));
+
 describe('ValidateActions', () => {
-  it('renders the page heading', async () => {
+  it('renders heading without tabs when user is not admin', async () => {
     renderWithAppContext(<ValidateActions />);
 
     const heading = await screen.findByRole('heading', {
@@ -13,5 +25,21 @@ describe('ValidateActions', () => {
     });
 
     expect(heading).toBeInTheDocument();
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+  });
+
+  it('renders heading and tabs with My Groups selected when user is admin', async () => {
+    renderWithAppContext(<ValidateActions />, {}, true);
+
+    const heading = await screen.findByRole('heading', {
+      level: 1,
+      name: /validate actions/i,
+    });
+    const tabs = await screen.findAllByRole('tab');
+
+    expect(heading).toBeInTheDocument();
+    expect(tabs.length).toBe(3);
+    expect(tabs[0]).toHaveTextContent(/my groups/i);
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
   });
 });

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -6,6 +6,7 @@ expect.extend(toHaveNoViolations);
 
 // Mock window object native functions
 global.scrollTo = jest.fn();
+global.createEvent = jest.fn();
 
 // Mock common hooks and dependencies
 jest.mock('./components/contexts/LanguageContext', () => ({

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -7,10 +7,16 @@ expect.extend(toHaveNoViolations);
 // Mock window object native functions
 global.scrollTo = jest.fn();
 global.createEvent = jest.fn();
+global.addEventListener = jest.fn();
 
 // Mock common hooks and dependencies
 jest.mock('./components/contexts/LanguageContext', () => ({
   useLanguageContext: () => ({
     language: 'en',
+  }),
+}));
+jest.mock('./components/contexts/ContentTranslationsContext', () => ({
+  useContentTranslationsContext: () => ({
+    langCode: 'en',
   }),
 }));

--- a/src/utils/jest-mock-utils.js
+++ b/src/utils/jest-mock-utils.js
@@ -1,0 +1,11 @@
+export const mockUser = {
+  user_id: 123,
+  name: 'Jest Tester',
+  email: 'jest-tester@email.com',
+  avatar: 'https://avatar.com/jest-tester.png',
+  total_co2: 238497994.31410018,
+  total_points: 238497997,
+  weekly_co2: 5040,
+  weekly_points: 238497997,
+  username: 'jesttester',
+};

--- a/src/utils/jest-mock-utils.js
+++ b/src/utils/jest-mock-utils.js
@@ -19,7 +19,7 @@ export const mockUser = {
 export const mockUserValues = {
   user: mockUser,
   userIsAdmin: false,
-  userType: '',
+  userType: 'Member',
   setUser: jest.fn(),
 };
 

--- a/src/utils/jest-mock-utils.js
+++ b/src/utils/jest-mock-utils.js
@@ -1,3 +1,9 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material';
+import { UserInfoContext } from '../hooks/use-user-info-context';
+import theme from '../themes';
+
 export const mockUser = {
   user_id: 123,
   name: 'Jest Tester',
@@ -9,3 +15,33 @@ export const mockUser = {
   weekly_points: 238497997,
   username: 'jesttester',
 };
+
+export const mockUserValues = {
+  user: mockUser,
+  userIsAdmin: false,
+  userType: '',
+  setUser: jest.fn(),
+};
+
+export const mockAdminUserValues = {
+  user: mockUser,
+  userIsAdmin: true,
+  userType: 'Admin',
+  setUser: jest.fn(),
+};
+
+export const renderWithAppContext = (
+  component,
+  renderOptions = {},
+  isAdmin = false
+) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <UserInfoContext.Provider
+        value={isAdmin ? mockAdminUserValues : mockUserValues}
+      >
+        {component}
+      </UserInfoContext.Provider>
+    </ThemeProvider>,
+    renderOptions
+  );

--- a/src/views/AppNav.js
+++ b/src/views/AppNav.js
@@ -125,5 +125,5 @@ export const AppNav = ({ handleMenuNavItem }) => {
 
 AppNav.propTypes = {
   ...BaseComponent,
-  handleMenuNavItem: PropTypes.func.isRequired,
+  handleMenuNavItem: PropTypes.func,
 };

--- a/src/views/AppNav.js
+++ b/src/views/AppNav.js
@@ -61,7 +61,7 @@ NavItem.propTypes = {
   label: PropTypes.string.isRequired,
 };
 
-const mainNavItems = [
+export const mainNavItems = [
   { name: 'logAction', iconName: 'log', pathName: 'LOG_ACTION' },
   { name: 'dashboard', iconName: 'home', pathName: 'DASHBOARD' },
   { name: 'actions', iconName: 'validate', pathName: 'ACTIONS' },

--- a/src/views/AppNav.test.js
+++ b/src/views/AppNav.test.js
@@ -1,19 +1,9 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { MemoryRouter } from 'react-router-dom';
-import { UserInfoContext } from '../hooks/use-user-info-context';
 import { AppNav, mainNavItems } from './AppNav';
-
-const mockHandleMenuNavItem = jest.fn();
-
-const AppNavWithProviders = ({ userIsAdmin = false, ...props }) => (
-  <MemoryRouter>
-    <UserInfoContext.Provider value={{ userIsAdmin }}>
-      <AppNav handleMenuNavItem={mockHandleMenuNavItem} {...props} />
-    </UserInfoContext.Provider>
-  </MemoryRouter>
-);
+import { renderWithAppContext } from '../utils/jest-mock-utils';
 
 const mainNavBaseLength = mainNavItems.length;
 const mainNavNotAdminLength = mainNavBaseLength + 1;
@@ -21,7 +11,9 @@ const mainNavAdminLength = mainNavBaseLength + 2;
 
 describe('AppNav', () => {
   it('renders links from mainNavItems plus my account link', async () => {
-    const { container } = render(<AppNavWithProviders />);
+    const { container } = renderWithAppContext(<AppNav />, {
+      wrapper: MemoryRouter,
+    });
 
     const results = await axe(container);
     const links = await screen.findAllByRole('link');
@@ -32,7 +24,7 @@ describe('AppNav', () => {
   });
 
   it('renders log action as first nav item', async () => {
-    render(<AppNavWithProviders />);
+    renderWithAppContext(<AppNav />, { wrapper: MemoryRouter });
 
     const links = await screen.findAllByRole('link');
 
@@ -40,7 +32,11 @@ describe('AppNav', () => {
   });
 
   it('renders additional admin dashboard link when user is admin', async () => {
-    const { container } = render(<AppNavWithProviders userIsAdmin={true} />);
+    const { container } = renderWithAppContext(
+      <AppNav />,
+      { wrapper: MemoryRouter },
+      true
+    );
 
     const results = await axe(container);
     const links = await screen.findAllByRole('link');

--- a/src/views/AppNav.test.js
+++ b/src/views/AppNav.test.js
@@ -1,20 +1,53 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
-import { AppNav } from './AppNav';
 import { MemoryRouter } from 'react-router-dom';
+import { UserInfoContext } from '../hooks/use-user-info-context';
+import { AppNav, mainNavItems } from './AppNav';
 
-var mockHandleMenuNavItem = jest.fn();
+const mockHandleMenuNavItem = jest.fn();
+
+const AppNavWithProviders = ({ userIsAdmin = false, ...props }) => (
+  <MemoryRouter>
+    <UserInfoContext.Provider value={{ userIsAdmin }}>
+      <AppNav handleMenuNavItem={mockHandleMenuNavItem} {...props} />
+    </UserInfoContext.Provider>
+  </MemoryRouter>
+);
+
+const mainNavBaseLength = mainNavItems.length;
+const mainNavNotAdminLength = mainNavBaseLength + 1;
+const mainNavAdminLength = mainNavBaseLength + 2;
 
 describe('AppNav', () => {
-  it('passes basic a11y validation', async () => {
-    const { container } = render(
-      <MemoryRouter>
-        <AppNav handleMenuNavItem={mockHandleMenuNavItem} />
-      </MemoryRouter>
-    );
+  it('renders links from mainNavItems plus my account link', async () => {
+    const { container } = render(<AppNavWithProviders />);
+
     const results = await axe(container);
+    const links = await screen.findAllByRole('link');
 
     expect(results).toHaveNoViolations();
+    expect(links.length).toEqual(mainNavNotAdminLength);
+    expect(links[mainNavNotAdminLength - 1]).toHaveTextContent(/my account/i);
+  });
+
+  it('renders log action as first nav item', async () => {
+    render(<AppNavWithProviders />);
+
+    const links = await screen.findAllByRole('link');
+
+    expect(links[0]).toHaveTextContent(/log action/i);
+  });
+
+  it('renders additional admin dashboard link when user is admin', async () => {
+    const { container } = render(<AppNavWithProviders userIsAdmin={true} />);
+
+    const results = await axe(container);
+    const links = await screen.findAllByRole('link');
+
+    expect(results).toHaveNoViolations();
+    expect(links.length).toEqual(mainNavAdminLength);
+    expect(links[mainNavAdminLength - 2]).toHaveTextContent(/admin dashboard/i);
+    expect(links[mainNavAdminLength - 1]).toHaveTextContent(/my account/i);
   });
 });


### PR DESCRIPTION
## Ticket

* [TIG-500](https://app.clickup.com/t/9009201449/TIG-500)

## Description

This PR adds basic tests for some high-level page components, including:

* `AccountSettings`
* `Actions`
* `AdminDashboard`
* `ValidateActions`

It also expands tests for `AppNav`, sets up reusable test utilities and mocking in `utils/jest-mock-utils.js`, and makes small a11y fixes throughout pages and their sub-components as caught by the `jest-axe` tool. 

This PR does not include tests for all pages, as the impact across multiple files and sub-files was growing more than seemed responsible. It does, however, setup patterns and practices which can be used by any other devs to help expand the coverage!

## Testing

* Pull down and install the branch
* From the root, run `npm run test`
* Confirm all tests pass
* Build the app locally using `npm start`
* Peruse the impacted pages in-browser to confirm no functionality has changed

## Screenshots

**Passing tests output in Terminal:**

![image](https://github.com/TakingITGlobal/commit2act/assets/1672105/20a6e6a2-e4c9-41c6-b7f2-5700b11c2aca)
